### PR TITLE
Remove unused dependency on setuptools_behave.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ import platform
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-from setuptools_behave import behave_test
 
 from nordicsemi import version
 
@@ -109,7 +108,6 @@ setup(
     ],
     cmdclass={
         'test': NoseTestCommand
-        # 'bdd_test': behave_test
     },
     entry_points='''
       [console_scripts]


### PR DESCRIPTION
Prior to this change, setup.py fails for me with this error:

```
Collecting git+https://github.com/NordicSemiconductor/pc-nrfutil.git (from -r requirements.txt (line 5))
  Cloning https://github.com/NordicSemiconductor/pc-nrfutil.git to /var/folders/kb/c1rlh6_96wz581gsgmr3llrm0000gp/T/pip-a_IAzI-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/var/folders/kb/c1rlh6_96wz581gsgmr3llrm0000gp/T/pip-a_IAzI-build/setup.py", line 44, in <module>
        from setuptools_behave import behave_test
    ImportError: No module named setuptools_behave
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /var/folders/kb/c1rlh6_96wz581gsgmr3llrm0000gp/T/pip-a_IAzI-build
```

behave_test is currently unused, so removing this dependency should simply make first-time installation smoother.

See #1.