### PR TITLE
Fixed bug where arguments passed when creating DFU package zip was in…

### DIFF
--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -148,22 +148,22 @@ class Package(object):
         self.firmwares_data = {}
 
         if app_fw:
-            self.__add_firmware_info(HexType.APPLICATION,
-                                     app_fw,
-                                     app_version,
-                                     init_packet_vars)
+            self.__add_firmware_info(firmware_type=HexType.APPLICATION,
+                                     firmware_version=app_version,
+                                     filename=app_fw,
+                                     init_packet_data=init_packet_vars)
 
         if bootloader_fw:
-            self.__add_firmware_info(HexType.BOOTLOADER,
-                                     bootloader_fw,
-                                     bootloader_version,
-                                     init_packet_vars)
+            self.__add_firmware_info(firmware_type=HexType.BOOTLOADER,
+                                     firmware_version=bootloader_version,
+                                     filename=bootloader_fw,
+                                     init_packet_data=init_packet_vars)
 
         if softdevice_fw:
-            self.__add_firmware_info(HexType.SOFTDEVICE,
-                                     softdevice_fw,
-                                     0xFFFFFFFF,
-                                     init_packet_vars)
+            self.__add_firmware_info(firmware_type=HexType.SOFTDEVICE,
+                                     firmware_version=0xFFFFFFFF,
+                                     filename=softdevice_fw,
+                                     init_packet_data=init_packet_vars)
 
         if key_file:
             self.key_file = key_file


### PR DESCRIPTION
… incorrect order.

The issue was that the order in which the arguments were sent to the
__app_firmware_info was wrong, resulting in the intended 'app_version'
(integer) being interpreted as a 'filename' (string) resulting in error
codes when attempting to create DFU zip packages.