### PR TITLE
MBTLE-751: force rtn code to match cmd result with sys.exit(n)

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -347,14 +347,13 @@ def serial(package, port, baudrate, flowcontrol, interval, mesh):
                    "press Button 4 and RESET and release both to enter DFU mode.")
 
         #click.echo("Trace:\r\n{0}".format(traceback.print_exc()))
-        return False
+        exit(-1)
     finally:
         serial_backend.close()
 
 
     click.echo("Device programmed.")
-
-    return True
+    exit(0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
with this you can use the process return code to check it transfer passed or failed.

in batch this is:
echo Exit Code is %errorlevel%

in bash it is: 
echo Exit Code is $?