### PR TITLE
Added hex folder to spec for PyInstall exe generation

### DIFF
--- a/nrfutil.spec
+++ b/nrfutil.spec
@@ -9,9 +9,10 @@ import sys
 module = importlib.import_module("pc_ble_driver_py")
 mod_dir = os.path.dirname(module.__file__)
 shlib_dir = os.path.join(os.path.abspath(mod_dir), 'lib')
+hex_dir  = os.path.join(os.path.abspath(mod_dir), 'hex')
 
 a = Analysis(['nordicsemi\\__main__.py'],
-             binaries=[(shlib_dir, "lib")],
+             binaries=[(shlib_dir, "lib"), (hex_dir, "pc_ble_driver_py\\hex")],
              datas=None,
              hiddenimports=[],
              hookspath=[],


### PR DESCRIPTION
Flashing of connectivity firmware fails when running a exe file generated using PyInstaller. The hex directory, containing connectivity firmware, is no longer included in lib directory. It need to be included in generated exe for flashing to work.