### PR TITLE
Bugfix/linux paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ python setup.py install
 To generate a self-contained executable version of the utility:  
 ```
 pyinstaller nrfutil.spec
+
+// on Linux prefix with the full path:
+pyinstaller /full/path/to/nrfutil.spec
 ```
 
 **Note**: Some anti-virus programs will stop PyInstaller from executing correctly when it modifies the executable file.

--- a/nrfutil.spec
+++ b/nrfutil.spec
@@ -11,8 +11,8 @@ mod_dir = os.path.dirname(module.__file__)
 shlib_dir = os.path.join(os.path.abspath(mod_dir), 'lib')
 hex_dir  = os.path.join(os.path.abspath(mod_dir), 'hex')
 
-a = Analysis(['nordicsemi\\__main__.py'],
-             binaries=[(shlib_dir, "lib"), (hex_dir, "pc_ble_driver_py\\hex")],
+a = Analysis(['nordicsemi/__main__.py'],
+             binaries=[(shlib_dir, "lib"), (hex_dir, "pc_ble_driver_py/hex")],
              datas=None,
              hiddenimports=[],
              hookspath=[],


### PR DESCRIPTION
Remove backslashes from paths to work on Linux. Update instructions for pyinstaller. Resolves #54.