### PR TITLE
Print error when fromhexfile fails

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -242,7 +242,11 @@ def generate(hex_file,
 def display(hex_file): 
 
     sett = BLDFUSettings()
-    sett.fromhexfile(hex_file)
+    try:
+        sett.fromhexfile(hex_file)
+    except NordicSemiException as err:
+        click.echo(err)
+        return
 
     click.echo("{0}".format(str(sett)))
 

--- a/nordicsemi/dfu/bl_dfu_sett.py
+++ b/nordicsemi/dfu/bl_dfu_sett.py
@@ -51,6 +51,7 @@ from nordicsemi.dfu import intelhex
 from nordicsemi.dfu.intelhex import IntelHexError
 from nordicsemi.dfu.nrfhex import *
 from nordicsemi.dfu.package import Package
+from pc_ble_driver_py.exceptions import NordicSemiException
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +234,7 @@ class BLDFUSettings(object):
                     self.probe_settings(BLDFUSettings.bl_sett_52840_addr)
                     self.set_arch('NRF52840')
                 except Exception as e:
-                    return "Failed to parse .hex file: {0}".format(e)
+                    raise NordicSemiException("Failed to parse .hex file: {0}".format(e))
        
     def __str__(self):
         s = """


### PR DESCRIPTION
This makes nrfutil output a human-readable error when failing to parse hex file:

> nrfutil settings display read.hex
Failed to parse .hex file: Bad access at 0xFF000: not enough data to read 4 contiguous bytes

Without this, I got non-informative traces like this:

> nrfutil settings display read.hex
Traceback (most recent call last):
  File "env/bin/nrfutil", line 11, in <module>
    sys.exit(cli())
  File "env/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "env/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "env/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "env/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "env/local/lib/python2.7/site-packages/nordicsemi/__main__.py", line 247, in display
    click.echo("{0}".format(str(sett)))
  File "env/local/lib/python2.7/site-packages/nordicsemi/dfu/bl_dfu_sett.py", line 252, in __str__
    """.format(self.hex_file, self.arch_str, self.crc, self.bl_sett_ver, self.app_ver, self.bl_ver, self.bank_layout, self.bank_current, self.app_sz, self.app_crc, self.bank0_bank_code)
AttributeError: 'BLDFUSettings' object has no attribute 'arch_str'