### PR TITLE
Remove unused import statement in __main__.py

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -36,7 +36,6 @@
 #
 import ipaddress
 import signal
-from nordicsemi.thread.dfu_server import ThreadDfuServer
 
 """nrfutil command line tool."""
 import os


### PR DESCRIPTION
An unused import statement in `__main__.py` caused problems when trying to run the project with `python nordicsemi/__main__.py`. Removing it.

Ref. issue #85.