### PR TITLE
Fix potential issues with ping during serial DFU

### DIFF
--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -187,9 +187,6 @@ class DfuTransportSerial(DfuTransport):
             raise NordicSemiException("Serial port could not be opened on {0}" 
             + ". Reason: {1}".format(self.com_port, e.message))
 
-        if self.__ping() == False:
-            raise NordicSemiException("No ping response after opening COM port")
-
         ping_success = False
         start = datetime.now()
         while datetime.now() - start < timedelta(seconds=self.timeout):

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -308,14 +308,17 @@ class DfuTransportSerial(DfuTransport):
         resp = self.dfu_adapter.get_message() # Receive raw reponse to check return code
 
         if (resp == None):
-            raise NordicSemiException('No ping response')
+            logger.debug('Serial: No ping response')
+            return False
 
         if resp[0] != DfuTransportSerial.OP_CODE['Response']:
-            raise NordicSemiException('No Response: 0x{:02X}'.format(resp[0]))
+            logger.debug('Serial: No Response: 0x{:02X}'.format(resp[0]))
+            return False
 
         if resp[1] != DfuTransportSerial.OP_CODE['Ping']:
-            raise NordicSemiException('Unexpected Executed OP_CODE.\n' \
-                              + 'Expected: 0x{:02X} Received: 0x{:02X}'.format(operation, resp[1]))
+            logger.debug('Serial: Unexpected Executed OP_CODE.\n' \
+                + 'Expected: 0x{:02X} Received: 0x{:02X}'.format(DfuTransportSerial.OP_CODE['Ping'], resp[1]))
+            return False
 
         if resp[2] != DfuTransport.RES_CODE['Success']:
             # Returning an error code is seen as good enough. The bootloader is up and running


### PR DESCRIPTION
Some potential issues with ping during serial DFU was identified in #84. I have tested to see if I can provoke an error related to this, but I have not been able to do so.

In any case, the current implementation had some obvious problems. As suggested in #84, I have removed the first ping in `open()`, and modified `__ping()` so that it returns `False` instead of raising exceptions. Verified that serial DFU still works with the example files from SDK 14.