### PR TITLE
Get port by jlink snr for BLE DFU

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -711,8 +711,7 @@ def ble(package, conn_ic_id, port, name, address, jlink_snr, flash_connectivity)
         click.echo("No target selected. Default device name: {} is used.".format(name))
 
     if port is None and jlink_snr is not None:
-        click.echo("Please specify also serial port.")
-        return
+        port = get_port_by_snr(jlink_snr)
 
     elif port is None:
         port = enumerate_ports()


### PR DESCRIPTION
The Thread DFU already uses this. Looking at the file history, I think this is only a oversight that it is not used on the BLE side.