### PR TITLE
Added usb_serial dfu option with optional ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pyinstaller /full/path/to/nrfutil.spec
 
 **Note**: Please refer to the [pc-ble-driver-py PyPI installation note on Windows](https://github.com/NordicSemiconductor/pc-ble-driver-py#installing-from-pypi) if you are running nrfutil on this operating system.
 
-**Note**: To use the `dfu ble` or `dfu thread` option you will need to set up your boards to be able to communicate with your computer.  You can find additional information here: [Hardware setup](https://github.com/NordicSemiconductor/pc-ble-driver/blob/master/Installation.md#hardware-setup). 
+**Note**: To use the `dfu ble` or `dfu thread` option you will need to set up your boards to be able to communicate with your computer.  You can find additional information here: [Hardware setup](https://github.com/NordicSemiconductor/pc-ble-driver/blob/master/Installation.md#hardware-setup).
 
 ## Usage
 
@@ -171,7 +171,7 @@ SD + APP      | Yes       | **See notes 1 and 2 below**
 
 **Note 1:** SD must be of the same Major Version as the old BL may not be compatible with the new SD.
 
-**Note 2:** When updating SD (+ BL) + APP the update is done in 2 following connections, unless a custom bootloader is used. First the SD (+ BL) is updated, then the bootloader will disconnect and the (new) BL will start advertising. Second connection to the bootloader will update the APP. However, the two SDs may have different IDs. The first update requires `--sd-req` to be set to the ID of the old SD. Update of the APP requires the ID of the new SD. In that case the new ID must be set using `--sd-id` parameter. This parameter is 
+**Note 2:** When updating SD (+ BL) + APP the update is done in 2 following connections, unless a custom bootloader is used. First the SD (+ BL) is updated, then the bootloader will disconnect and the (new) BL will start advertising. Second connection to the bootloader will update the APP. However, the two SDs may have different IDs. The first update requires `--sd-req` to be set to the ID of the old SD. Update of the APP requires the ID of the new SD. In that case the new ID must be set using `--sd-id` parameter. This parameter is
 was added in nrfutil 3.1.0 and is required since 3.2.0 in case the package should contain SD (+ BL) + APP. Also, since version 3.2.0 the new ID is copied to `--sd-req` list so that
 in case of a link loss during APP update the DFU process can be restarted. In that case the new SD would overwrite itself, so `--sd-req` must contain also the ID of the new SD.
 
@@ -216,6 +216,16 @@ nrfutil dfu serial --help
 Below is an example of the execution of a DFU procedure of the file generated above over COM3:
 ```
 nrfutil dfu serial -pkg app_dfu_package.zip -p COM3
+```
+
+##### usb_serial
+Perform a full DFU procedure over a serial (UART) line. This command is the same as `serial` but initial ping is not performed. It provides the possibility of enabling the ping feature, which is always performed in case of `serial`.
+```
+nrfutil dfu usb_serial --help
+```
+Below is an example of the execution of a DFU procedure of the file generated above over COM3:
+```
+nrfutil dfu usb_serial -pkg app_dfu_package.zip -p COM3
 ```
 
 #### keys
@@ -315,4 +325,3 @@ Refer to [init_packet_pb.py](nordicsemi/dfu/init_packet_pb.py) and [package.py](
 ### Adapting the bootloader to the new Init Packet format
 
 Since you have modified the Init Packet format you will have to do the same with the embedded bootloader, which can be found in the Nordic nRF5 SDK under `examples/dfu/bootloader_secure`.
-

--- a/README.md
+++ b/README.md
@@ -210,12 +210,12 @@ The `-f` option instructs nrfutil to actually program the board connected to COM
 
 ##### serial
 
-Perform a full DFU procedure over an UART serial line. The DFU target shall be configured to use some of its digital I/O pins as an UART.
+Perform a full DFU procedure over a UART serial line. The DFU target shall be configured to use some of its digital I/O pins as UART.
 
 Please note that most Nordic development kit boards have an [interface MCU](http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fdevelopment%2Fnrf52_dev_kit%2Finterf_mcu.html&cp=2_1_4_4)
 which transparently [maps digital pins 6 and 8 into a CDC ACM USB interface (A.K.A. "USB virtual serial port")](http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fdevelopment%2Fnrf52_dev_kit%2Fvir_com_port.html&cp=2_1_4_4_1).
 Use `serial` DFU mode when communicating with a nRF chip in this way. Otherwise you may
-connect the digital I/O pins to a RS232 connector.
+connect the digital I/O pins to an RS232 connector.
 
 This command takes several options that you can list using:
 

--- a/README.md
+++ b/README.md
@@ -209,21 +209,39 @@ nrfutil dfu ble -pkg app_dfu_package.zip -p COM3 -f
 The `-f` option instructs nrfutil to actually program the board connected to COM3 with the connectivity software required to operate as a network co-processor (NCP). Use with caution as this will overwrite the contents of the IC's flash memory.
 
 ##### serial
-Perform a full DFU procedure over a serial (UART) line. This command takes several options that you can list using:
+
+Perform a full DFU procedure over an UART serial line. The DFU target shall be configured to use some of its digital I/O pins as an UART.
+
+Please note that most Nordic development kit boards have an [interface MCU](http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fdevelopment%2Fnrf52_dev_kit%2Finterf_mcu.html&cp=2_1_4_4)
+which transparently [maps digital pins 6 and 8 into a CDC ACM USB interface (A.K.A. "USB virtual serial port")](http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fdevelopment%2Fnrf52_dev_kit%2Fvir_com_port.html&cp=2_1_4_4_1).
+Use `serial` DFU mode when communicating with a nRF chip in this way. Otherwise you may
+connect the digital I/O pins to a RS232 connector.
+
+This command takes several options that you can list using:
+
 ```
 nrfutil dfu serial --help
 ```
+
 Below is an example of the execution of a DFU procedure of the file generated above over COM3:
+
 ```
 nrfutil dfu serial -pkg app_dfu_package.zip -p COM3
 ```
 
 ##### usb_serial
-Perform a full DFU procedure over a serial (UART) line. This command is the same as `serial` but initial ping is not performed. It provides the possibility of enabling the ping feature, which is always performed in case of `serial`.
+
+Perform a full DFU procedure over a CDC ACM USB connection (A.K.A. "USB virtual serial port"). The DFU target shall be a chip with USB pins (i.e. nRF52840), and shall be running a bootloader enabling a USB-CDC interface.
+
+In the case of the nRF52840 development kit board, the `usb_serial` DFU mode is used when communicating with the board through the female USB port marked "nRF USB", which is wired
+to the USB pins in the nRF chip.
+
 ```
 nrfutil dfu usb_serial --help
 ```
+
 Below is an example of the execution of a DFU procedure of the file generated above over COM3:
+
 ```
 nrfutil dfu usb_serial -pkg app_dfu_package.zip -p COM3
 ```

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -631,13 +631,13 @@ def do_serial(package, port, flow_control, packet_receipt_notification, baud_rat
 
     click.echo("Device programmed.")
 
-@dfu.command(short_help="Update the firmware on a device over a USB serial connection.")
+@dfu.command(short_help="Update the firmware on a device over a USB serial connection. The DFU target must be a chip with USB pins (i.e. nRF52840) and provide a USB ACM CDC serial interface.")
 @click.option('-pkg', '--package',
               help='Filename of the DFU package.',
               type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=False),
               required=True)
 @click.option('-p', '--port',
-              help='USB Serial COM port to which the device is connected.',
+              help='Serial port address to which the device is connected. (e.g. COM1 in windows systems, /dev/ttyACM0 in linux/mac)',
               type=click.STRING,
               required=True)
 @click.option('-fc', '--flow-control',
@@ -653,7 +653,7 @@ def do_serial(package, port, flow_control, packet_receipt_notification, baud_rat
               type=click.INT,
               required=False)
 @click.option('-P', '--ping',
-              help='Ping the device after opening the connection',
+              help='Ping the device after opening the connection.',
               type=click.BOOL,
               required=False)
 def usb_serial(package, port, flow_control, packet_receipt_notification, baud_rate, ping):
@@ -662,13 +662,13 @@ def usb_serial(package, port, flow_control, packet_receipt_notification, baud_ra
     do_serial(package, port, flow_control, packet_receipt_notification, baud_rate, ping)
 
 
-@dfu.command(short_help="Update the firmware on a device over a serial connection.")
+@dfu.command(short_help="Update the firmware on a device over a UART serial connection. The DFU target must be a chip using digital I/O pins as an UART. Note that ")
 @click.option('-pkg', '--package',
               help='Filename of the DFU package.',
               type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=False),
               required=True)
 @click.option('-p', '--port',
-              help='Serial port COM port to which the device is connected.',
+              help='Serial port address to which the device is connected. (e.g. COM1 in windows systems, /dev/ttyACM0 in linux/mac)',
               type=click.STRING,
               required=True)
 @click.option('-fc', '--flow-control',

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -169,7 +169,7 @@ def version():
 @cli.group(short_help='Generate and display Bootloader DFU settings.')
 def settings():
     """
-    This set of commands supports creating and displaying bootloader settings. 
+    This set of commands supports creating and displaying bootloader settings.
     """
     pass
 
@@ -230,11 +230,11 @@ def generate(hex_file,
     if bootloader_version is None:
         click.echo("Error: Bootloader version required.")
         return
- 
+
     if bl_settings_version is None:
         click.echo("Error: Bootloader DFU settings version required.")
         return
-       
+
     sett = BLDFUSettings()
     sett.generate(arch=family, app_file=application, app_ver=application_version_internal, bl_ver=bootloader_version, bl_sett_ver=bl_settings_version)
     sett.tohexfile(hex_file)
@@ -246,7 +246,7 @@ def generate(hex_file,
 @settings.command(short_help='Display the contents of a .hex file with Bootloader DFU settings.')
 @click.argument('hex_file', required=True, type=click.Path())
 
-def display(hex_file): 
+def display(hex_file):
 
     sett = BLDFUSettings()
     try:
@@ -269,10 +269,10 @@ def keys():
 
 @keys.command(short_help='Generate a private key and store it in a file in PEM format.')
 @click.argument('key_file', required=True, type=click.Path())
-              
+
 def generate(key_file):
     signer = Signing()
-    
+
     if os.path.exists(key_file):
         if not query_func("File found at %s. Do you want to overwrite the file?" % key_file):
             click.echo('Key generation aborted.')
@@ -329,7 +329,7 @@ def display(key_file, key, format, out_file):
 
     if key == "pk":
         kstr = signer.get_vk(format, dbg)
-    elif key == "sk": 
+    elif key == "sk":
         kstr = "\nWARNING: Security risk! Do not share the private key.\n\n"
         kstr = kstr + signer.get_sk(format, dbg)
 
@@ -430,7 +430,7 @@ def generate(zipfile,
     * SD only: Supported (SD of same Major Version).
 
     * APP only: Supported.
-   
+
     * BL + SD: Supported.
 
     * BL + APP: Not supported (use two packages instead).
@@ -514,16 +514,16 @@ def generate(zipfile,
         click.echo("Error: --hw-version required.")
         return
 
-    if sd_req is None: 
+    if sd_req is None:
         click.echo("Error: --sd-req required.")
         return
 
-    if application is not None and application_version_internal is None: 
+    if application is not None and application_version_internal is None:
         click.echo('Error: --application-version or --application-version-string'
                    'required with application image.')
         return
 
-    if bootloader is not None and bootloader_version is None: 
+    if bootloader is not None and bootloader_version is None:
         click.echo("Error: --bootloader-version required with bootloader image.")
         return
 
@@ -551,7 +551,7 @@ def generate(zipfile,
             # Copy all IDs from sd_id_list to sd_req_list, without duplicates.
             # This ensures that the softdevice update can be repeated in case
             # SD+(BL)+App update terminates during application update after the
-            # softdevice was already updated (with new ID). Such update would 
+            # softdevice was already updated (with new ID). Such update would
             # have to be repeated and the softdevice would have to be sent again,
             # this time updating itself.
             sd_req_list += set(sd_id_list) - set(sd_req_list)
@@ -585,7 +585,7 @@ def generate(zipfile,
 @pkg.command(short_help='Display the contents of a .zip package file.')
 @click.argument('zip_file', required=True, type=click.Path())
 
-def display(zip_file): 
+def display(zip_file):
 
     package = Package()
     package.parse_package(zip_file, preserve_work_dir=True)
@@ -603,6 +603,63 @@ def dfu():
     This set of commands supports Device Firmware Upgrade procedures over both BLE and serial transports.
     """
     pass
+
+def do_serial(package, port, flow_control, packet_receipt_notification, baud_rate, ping):
+
+    if flow_control is None:
+        flow_control = DfuTransportSerial.DEFAULT_FLOW_CONTROL
+    if packet_receipt_notification is None:
+        packet_receipt_notification = DfuTransportSerial.DEFAULT_PRN
+    if baud_rate is None:
+        baud_rate = DfuTransportSerial.DEFAULT_BAUD_RATE
+    if ping is None:
+        ping = False
+
+    logger.info("Using board at serial port: {}".format(port))
+    serial_backend = DfuTransportSerial(com_port=str(port), baud_rate=baud_rate,
+                    flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping)
+    serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
+    dfu = Dfu(zip_file_path = package, dfu_transport = serial_backend)
+
+    if logger.getEffectiveLevel() > logging.INFO:
+        with click.progressbar(length=dfu.dfu_get_total_size()) as bar:
+            global global_bar
+            global_bar = bar
+            dfu.dfu_send_images()
+    else:
+        dfu.dfu_send_images()
+
+    click.echo("Device programmed.")
+
+@dfu.command(short_help="Update the firmware on a device over a USB serial connection.")
+@click.option('-pkg', '--package',
+              help='Filename of the DFU package.',
+              type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=False),
+              required=True)
+@click.option('-p', '--port',
+              help='USB Serial COM port to which the device is connected.',
+              type=click.STRING,
+              required=True)
+@click.option('-fc', '--flow-control',
+              help='To enable flow control set this flag to 1',
+              type=click.BOOL,
+              required=False)
+@click.option('-prn', '--packet-receipt-notification',
+              help='Set the packet receipt notification value',
+              type=click.INT,
+              required=False)
+@click.option('-b', '--baud-rate',
+              help='Set the baud rate',
+              type=click.INT,
+              required=False)
+@click.option('-P', '--ping',
+              help='Ping the device after opening the connection',
+              type=click.BOOL,
+              required=False)
+def usb_serial(package, port, flow_control, packet_receipt_notification, baud_rate, ping):
+    """Perform a Device Firmware Update on a device with a bootloader that supports USB serial DFU."""
+
+    do_serial(package, port, flow_control, packet_receipt_notification, baud_rate, ping)
 
 
 @dfu.command(short_help="Update the firmware on a device over a serial connection.")
@@ -628,35 +685,8 @@ def dfu():
               required=False)
 def serial(package, port, flow_control, packet_receipt_notification, baud_rate):
     """Perform a Device Firmware Update on a device with a bootloader that supports serial DFU."""
-    #raise NotImplementedException('Serial transport currently is not supported')
-    """Perform a Device Firmware Update on a device with a bootloader that supports BLE DFU."""
 
-    if port is None:
-        click.echo("Please specify serial port.")
-        return
-        
-    if flow_control is None:
-        flow_control = DfuTransportSerial.DEFAULT_FLOW_CONTROL
-    if packet_receipt_notification is None:
-        packet_receipt_notification = DfuTransportSerial.DEFAULT_PRN
-    if baud_rate is None:
-        baud_rate = DfuTransportSerial.DEFAULT_BAUD_RATE
-
-    logger.info("Using board at serial port: {}".format(port))    
-    serial_backend = DfuTransportSerial(com_port=str(port), baud_rate=baud_rate, 
-                    flow_control=flow_control, prn=packet_receipt_notification)
-    serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
-    dfu = Dfu(zip_file_path = package, dfu_transport = serial_backend)
-
-    if logger.getEffectiveLevel() > logging.INFO:
-        with click.progressbar(length=dfu.dfu_get_total_size()) as bar:
-            global global_bar
-            global_bar = bar
-            dfu.dfu_send_images()
-    else:
-        dfu.dfu_send_images()
-
-    click.echo("Device programmed.")
+    do_serial(package, port, flow_control, packet_receipt_notification, baud_rate, True)
 
 
 def enumerate_ports():
@@ -720,7 +750,7 @@ def ble(package, conn_ic_id, port, name, address, jlink_snr, flash_connectivity)
             return
 
     if flash_connectivity:
-        flasher = Flasher(serial_port=port, snr = jlink_snr) 
+        flasher = Flasher(serial_port=port, snr = jlink_snr)
         if flasher.fw_check():
             click.echo("Board already flashed with connectivity firmware.")
         else:
@@ -737,7 +767,7 @@ def ble(package, conn_ic_id, port, name, address, jlink_snr, flash_connectivity)
     ble_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
     dfu = Dfu(zip_file_path = package, dfu_transport = ble_backend)
 
-    if logger.getEffectiveLevel() > logging.INFO: 
+    if logger.getEffectiveLevel() > logging.INFO:
         with click.progressbar(length=dfu.dfu_get_total_size()) as bar:
             global global_bar
             global_bar = bar


### PR DESCRIPTION
Added new dfu option `usb_serial` which calls the same old serial transport, but - by default - skips the ping functionality, that can be controlled by the `-P|--ping` optional bool argument.

The old `serial` transport doesn't offer this option, it always calls the ping.