### PR TITLE
Allow creation of sign-less init packets

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -84,6 +84,25 @@ def display_sec_warning():
 """
     click.echo("{}".format(default_key_warning))
 
+def display_nokey_warning():
+    default_nokey_warning = """
+|===============================================================|
+|##      ##    ###    ########  ##    ## #### ##    ##  ######  |
+|##  ##  ##   ## ##   ##     ## ###   ##  ##  ###   ## ##    ## |
+|##  ##  ##  ##   ##  ##     ## ####  ##  ##  ####  ## ##       |
+|##  ##  ## ##     ## ########  ## ## ##  ##  ## ## ## ##   ####|
+|##  ##  ## ######### ##   ##   ##  ####  ##  ##  #### ##    ## |
+|##  ##  ## ##     ## ##    ##  ##   ###  ##  ##   ### ##    ## |
+| ###  ###  ##     ## ##     ## ##    ## #### ##    ##  ######  |
+|===============================================================|
+|You are not providing a signature key, which means the DFU     |
+|files will not be signed, and are vulnerable to tampering.     |
+|This is only compatible with a signature-less bootloader and is|
+|not suitable for production environments.                      |
+|===============================================================|
+"""
+    click.echo("{}".format(default_nokey_warning))
+
 def display_debug_warning():
     debug_warning = """
 |===============================================================|
@@ -573,7 +592,9 @@ def generate(zipfile,
     else:
         sd_id_list = sd_req_list
 
-    if key_file is not None:
+    if key_file is None:
+        display_nokey_warning()
+    else:
         signer = Signing()
         default_key = signer.load_key(key_file)
         if default_key:

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -350,7 +350,7 @@ def display(key_file, key, format, out_file):
             kfile.write(kstr)
 
 
-@cli.group(short_help='Generate a Device Firmware Update package.')
+@cli.group(short_help='Display or generate a DFU package (zip file).')
 def pkg():
     """
     This set of commands supports Nordic DFU package generation.
@@ -358,7 +358,7 @@ def pkg():
     pass
 
 
-@pkg.command(short_help='Generate a firmware package for over-the-air firmware updates.')
+@pkg.command(short_help='Generate a zip file for performing DFU.')
 @click.argument('zipfile',
                 required=True,
                 type=click.Path())
@@ -384,6 +384,7 @@ def pkg():
               type=BASED_INT_OR_NONE)
 @click.option('--hw-version',
               help='The hardware version.',
+              required=True,
               type=BASED_INT)
 @click.option('--sd-req',
               help='The SoftDevice requirements. A comma-separated list of SoftDevice firmware IDs (1 or more) '
@@ -402,6 +403,7 @@ def pkg():
                    '\n|s132_nrf52_4.0.4|0x9E|'
                    '\n|s132_nrf52_5.0.0|0x9D|',
               type=click.STRING,
+              required=True,
               multiple=True)
 @click.option('--sd-id',
               help='The new SoftDevice ID to be used as --sd-req for the Application update in case the ZIP '
@@ -413,7 +415,7 @@ def pkg():
               type=click.STRING)
 @click.option('--key-file',
               help='The private (signing) key in PEM fomat.',
-              required=True,
+              required=False,
               type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=False))
 def generate(zipfile,
            debug_mode,
@@ -530,7 +532,7 @@ def generate(zipfile,
 
     if application is not None and application_version_internal is None:
         click.echo('Error: --application-version or --application-version-string'
-                   'required with application image.')
+                   ' required with application image.')
         return
 
     if bootloader is not None and bootloader_version is None:
@@ -571,10 +573,11 @@ def generate(zipfile,
     else:
         sd_id_list = sd_req_list
 
-    signer = Signing()
-    default_key = signer.load_key(key_file)
-    if default_key:
-        display_sec_warning()
+    if key_file is not None:
+        signer = Signing()
+        default_key = signer.load_key(key_file)
+        if default_key:
+            display_sec_warning()
 
     package = Package(debug_mode,
                       hw_version,
@@ -607,7 +610,7 @@ def update_progress(progress=0):
     if global_bar:
         global_bar.update(progress)
 
-@cli.group(short_help='Perform a Device Firmware Update over, BLE, Thread, or serial transport.')
+@cli.group(short_help='Perform a Device Firmware Update over, BLE, Thread, or serial transport given a DFU package (zip file).')
 def dfu():
     """
     This set of commands supports Device Firmware Upgrade procedures over both BLE and serial transports.

--- a/nordicsemi/dfu/dfu-cc.proto
+++ b/nordicsemi/dfu/dfu-cc.proto
@@ -23,8 +23,7 @@ enum HashType {
 	SHA512	= 4;
 }
 
-message Hash
-{
+message Hash {
 	required HashType 	hash_type	= 1;
 	required bytes 		hash		= 2;
 }
@@ -45,8 +44,7 @@ message InitCommand {
     optional bool   is_debug    = 9 [default = false];
 }
 
-message ResetCommand
-{
+message ResetCommand {
 	required uint32 timeout	= 1;
 }
 

--- a/nordicsemi/dfu/init_packet_pb.py
+++ b/nordicsemi/dfu/init_packet_pb.py
@@ -79,15 +79,24 @@ class InitPacketPB(object):
             # construct from a protobuf string/buffer
             self.packet = pb.Packet()
             self.packet.ParseFromString(from_bytes)
-            self.signed_command = self.packet.signed_command
-            self.init_command = self.signed_command.command.init
+
+            if self.packet.HasField('signed_command'):
+                self.init_command = self.packet.signed_command.command.init
+            else:
+                self.init_command = self.packet.command.init
+
         else:
             # construct from input variables
             if not sd_req:
                 sd_req = [0xfffe]  # Set to default value
             self.packet = pb.Packet()
-            self.signed_command = self.packet.signed_command
-            self.init_command = self.signed_command.command.init
+
+            # By default, set the packet's command to an unsigned command
+            # If a signature is set (via set_signature), this will get overwritten
+            # with an instance of SignedCommand instead.
+            self.packet.command.op_code = pb.INIT
+
+            self.init_command = pb.InitCommand()
             self.init_command.hash.hash_type = hash_type.value
             self.init_command.type = dfu_type.value
             self.init_command.hash.hash = hash_bytes
@@ -98,7 +107,8 @@ class InitPacketPB(object):
             self.init_command.sd_size = sd_size
             self.init_command.bl_size = bl_size
             self.init_command.app_size = app_size
-            self.signed_command.command.op_code = pb.INIT
+
+            self.packet.command.init.CopyFrom(self.init_command)
 
         self._validate()
 
@@ -127,17 +137,18 @@ class InitPacketPB(object):
         return self.signed_command.signature is not None
 
     def get_init_packet_pb_bytes(self):
-        if self.signed_command.signature is not None:
-            return self.packet.SerializeToString()
-        else:
-            raise RuntimeError("Did not set signature")
+        return self.packet.SerializeToString()
 
     def get_init_command_bytes(self):
         return self.init_command.SerializeToString()
 
     def set_signature(self, signature, signature_type):
-        self.signed_command.signature = signature
-        self.signed_command.signature_type = signature_type.value
+        new_packet = pb.Packet()
+        new_packet.signed_command.signature = signature
+        new_packet.signed_command.signature_type = signature_type.value
+        new_packet.signed_command.command.CopyFrom(self.packet.command)
+
+        self.packet = new_packet
 
     def __str__(self):
         return str(self.init_command)

--- a/nordicsemi/dfu/init_packet_pb.py
+++ b/nordicsemi/dfu/init_packet_pb.py
@@ -116,7 +116,7 @@ class InitPacketPB(object):
 
         if self.init_command.fw_version < 0 or self.init_command.fw_version > 0xffffffff or \
            self.init_command.hw_version < 0 or self.init_command.hw_version > 0xffffffff:
-            raise RuntimeError("Invalid range of firmware argument. [0 - 0xffffff] is valid range")
+            raise RuntimeError("Invalid range of firmware argument. [0 - 0xffffffff] is valid range")
 
     def _is_valid(self):
         try:

--- a/nordicsemi/dfu/init_packet_pb.py
+++ b/nordicsemi/dfu/init_packet_pb.py
@@ -76,7 +76,7 @@ class InitPacketPB(object):
                  ):
 
         if from_bytes is not None:
-            # construct from a stream
+            # construct from a protobuf string/buffer
             self.packet = pb.Packet()
             self.packet.ParseFromString(from_bytes)
             self.signed_command = self.packet.signed_command

--- a/tests/protobuf/__main__.py
+++ b/tests/protobuf/__main__.py
@@ -5,7 +5,7 @@ import os, sys
 
 sys.path.append(os.path.join('..', '..', 'nordicsemi'))
 
-from nordicsemi.dfu.init_packet_pb import InitPacketPB, HashTypes, DFUType
+from nordicsemi.dfu.init_packet_pb import InitPacketPB, HashTypes, DFUType, SigningTypes
 
 
 class TestStringMethods(unittest.TestCase):
@@ -41,8 +41,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_construct_from_params(self):
         """
-        Raises an error when the trying to construct a init packet from a
-        string that does not contain "app_size"
+        Gracefully constructs a init packet protobuffer from parameters without bytes
         """
 
         i = InitPacketPB(
@@ -60,6 +59,43 @@ class TestStringMethods(unittest.TestCase):
                  sd_req=[0xffffffff]
                 )
 
+        protobuf_bytes = i.get_init_command_bytes(); # bytes only for the InitCommand
+        hex_bytes = protobuf_bytes.encode('hex_codec');
+
+        self.assertEqual(hex_bytes, "08ffffffff0f10ffffffff0f1a05ffffffff0f20002800"
+                         "300038d2094204080312004800")
+
+        #print i.get_init_packet_pb_bytes();
+
+
+    def test_construct_from_params_and_sign(self):
+        """
+        Gracefully constructs a init packet protobuffer from parameters without bytes,
+        then signs it
+        """
+
+        i = InitPacketPB(
+                from_bytes = None,
+
+                 hash_bytes = b"",
+                 hash_type = HashTypes.SHA256,
+                 dfu_type = DFUType.APPLICATION,
+                 is_debug=False,
+                 fw_version=0xffffffff,
+                 hw_version=0xffffffff,
+                 sd_size=0,
+                 app_size=1234,
+                 bl_size=0,
+                 sd_req=[0xffffffff]
+                )
+
+        i.set_signature(b"signature bytes go here", SigningTypes.ECDSA_P256_SHA256)
+
+        protobuf_bytes = i.get_init_packet_pb_bytes(); # Bytes for the whole Packet
+        hex_bytes = protobuf_bytes.encode('hex_codec');
+
+        self.assertEqual(hex_bytes, "12450a280801122408ffffffff0f10ffffffff0f1a" "05ffffffff0f20002800300038d209420408031200480010001a177369676e61747572"
+        "6520627974657320676f2068657265")
 
 
 if __name__ == '__main__':

--- a/tests/protobuf/__main__.py
+++ b/tests/protobuf/__main__.py
@@ -1,9 +1,17 @@
 
 import unittest
-
 import os, sys
 
-sys.path.append(os.path.join('..', '..', 'nordicsemi'))
+sys.path.append(
+    os.path.normpath(
+        os.path.join(
+            os.path.dirname(__file__), '..', '..' # , 'nordicsemi'
+        )
+    )
+)
+
+#from nordicsemi.version import NRFUTIL_VERSION
+#print NRFUTIL_VERSION
 
 from nordicsemi.dfu.init_packet_pb import InitPacketPB, HashTypes, DFUType, SigningTypes
 
@@ -29,7 +37,7 @@ class TestStringMethods(unittest.TestCase):
     def test_construct_from_empty_string(self):
         """
         Raises an error when the trying to construct a init packet from a
-        string that does not contain "app_size"
+        empty buffer
         """
 
         self.assertRaisesRegexp(
@@ -96,6 +104,35 @@ class TestStringMethods(unittest.TestCase):
 
         self.assertEqual(hex_bytes, "12450a280801122408ffffffff0f10ffffffff0f1a" "05ffffffff0f20002800300038d209420408031200480010001a177369676e61747572"
         "6520627974657320676f2068657265")
+
+
+    def test_construct_from_params_and_not_sign(self):
+        """
+        Gracefully constructs a init packet protobuffer from parameters without bytes,
+        then signs it
+        """
+
+        i = InitPacketPB(
+                from_bytes = None,
+
+                 hash_bytes = b"",
+                 hash_type = HashTypes.SHA256,
+                 dfu_type = DFUType.APPLICATION,
+                 is_debug=False,
+                 fw_version=0xffffffff,
+                 hw_version=0xffffffff,
+                 sd_size=0,
+                 app_size=1234,
+                 bl_size=0,
+                 sd_req=[0xffffffff]
+                )
+
+        protobuf_bytes = i.get_init_packet_pb_bytes(); # Bytes for the whole Packet
+        hex_bytes = protobuf_bytes.encode('hex_codec');
+
+        self.assertEqual(hex_bytes, "0a280801122408ffffffff0f10ffffffff0f1a"
+        "05ffffffff0f20002800300038d2094204080312004800")
+
 
 
 if __name__ == '__main__':

--- a/tests/protobuf/__main__.py
+++ b/tests/protobuf/__main__.py
@@ -5,7 +5,7 @@ import os, sys
 sys.path.append(
     os.path.normpath(
         os.path.join(
-            os.path.dirname(__file__), '..', '..' # , 'nordicsemi'
+            os.path.dirname(__file__), '..', '..'
         )
     )
 )
@@ -16,7 +16,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_construct_from_empty_string(self):
         """
-        Raises an error when the trying to construct a init packet from a
+        Raises an error when trying to construct a init packet from an
         empty buffer
         """
 
@@ -29,7 +29,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_construct_from_params(self):
         """
-        Gracefully constructs a init packet protobuffer from parameters without bytes
+        Gracefully constructs an init packet protobuffer from parameters without bytes
         """
 
         i = InitPacketPB(
@@ -53,12 +53,10 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(hex_bytes, "08ffffffff0f10ffffffff0f1a05ffffffff0f20002800"
                          "300038d2094204080312004800")
 
-        #print i.get_init_packet_pb_bytes();
-
 
     def test_construct_from_params_and_sign(self):
         """
-        Gracefully constructs a init packet protobuffer from parameters without bytes,
+        Gracefully constructs an init packet protobuffer from parameters without bytes,
         then signs it
         """
 
@@ -89,8 +87,8 @@ class TestStringMethods(unittest.TestCase):
 
     def test_construct_from_params_and_not_sign(self):
         """
-        Gracefully constructs a init packet protobuffer from parameters without bytes,
-        then signs it
+        Gracefully constructs an init packet protobuffer from parameters without bytes,
+        skipping the signature process
         """
 
         i = InitPacketPB(

--- a/tests/protobuf/__main__.py
+++ b/tests/protobuf/__main__.py
@@ -1,0 +1,67 @@
+
+import unittest
+
+import os, sys
+
+sys.path.append(os.path.join('..', '..', 'nordicsemi'))
+
+from nordicsemi.dfu.init_packet_pb import InitPacketPB, HashTypes, DFUType
+
+
+class TestStringMethods(unittest.TestCase):
+
+    #def test_upper(self):
+        #self.assertEqual('foo'.upper(), 'FOO')
+
+    #def test_isupper(self):
+        #self.assertTrue('FOO'.isupper())
+        #self.assertFalse('Foo'.isupper())
+
+    #def test_split(self):
+        #s = 'hello world'
+        #self.assertEqual(s.split(), ['hello', 'world'])
+        ## check that s.split fails when the separator is not a string
+        #with self.assertRaises(TypeError):
+            #s.split(2)
+
+
+
+    def test_construct_from_empty_string(self):
+        """
+        Raises an error when the trying to construct a init packet from a
+        string that does not contain "app_size"
+        """
+
+        self.assertRaisesRegexp(
+            RuntimeError,
+            "app_size is not set. It must be set when type is APPLICATION",
+            InitPacketPB,
+            from_bytes = "");
+
+
+    def test_construct_from_params(self):
+        """
+        Raises an error when the trying to construct a init packet from a
+        string that does not contain "app_size"
+        """
+
+        i = InitPacketPB(
+                from_bytes = None,
+
+                 hash_bytes = b"",
+                 hash_type = HashTypes.SHA256,
+                 dfu_type = DFUType.APPLICATION,
+                 is_debug=False,
+                 fw_version=0xffffffff,
+                 hw_version=0xffffffff,
+                 sd_size=0,
+                 app_size=1234,
+                 bl_size=0,
+                 sd_req=[0xffffffff]
+                )
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/protobuf/__main__.py
+++ b/tests/protobuf/__main__.py
@@ -10,29 +10,9 @@ sys.path.append(
     )
 )
 
-#from nordicsemi.version import NRFUTIL_VERSION
-#print NRFUTIL_VERSION
-
 from nordicsemi.dfu.init_packet_pb import InitPacketPB, HashTypes, DFUType, SigningTypes
 
-
 class TestStringMethods(unittest.TestCase):
-
-    #def test_upper(self):
-        #self.assertEqual('foo'.upper(), 'FOO')
-
-    #def test_isupper(self):
-        #self.assertTrue('FOO'.isupper())
-        #self.assertFalse('Foo'.isupper())
-
-    #def test_split(self):
-        #s = 'hello world'
-        #self.assertEqual(s.split(), ['hello', 'world'])
-        ## check that s.split fails when the separator is not a string
-        #with self.assertRaises(TypeError):
-            #s.split(2)
-
-
 
     def test_construct_from_empty_string(self):
         """
@@ -53,19 +33,19 @@ class TestStringMethods(unittest.TestCase):
         """
 
         i = InitPacketPB(
-                from_bytes = None,
+            from_bytes = None,
 
-                 hash_bytes = b"",
-                 hash_type = HashTypes.SHA256,
-                 dfu_type = DFUType.APPLICATION,
-                 is_debug=False,
-                 fw_version=0xffffffff,
-                 hw_version=0xffffffff,
-                 sd_size=0,
-                 app_size=1234,
-                 bl_size=0,
-                 sd_req=[0xffffffff]
-                )
+            hash_bytes = b"",
+            hash_type = HashTypes.SHA256,
+            dfu_type = DFUType.APPLICATION,
+            is_debug=False,
+            fw_version=0xffffffff,
+            hw_version=0xffffffff,
+            sd_size=0,
+            app_size=1234,
+            bl_size=0,
+            sd_req=[0xffffffff]
+            )
 
         protobuf_bytes = i.get_init_command_bytes(); # bytes only for the InitCommand
         hex_bytes = protobuf_bytes.encode('hex_codec');
@@ -83,26 +63,27 @@ class TestStringMethods(unittest.TestCase):
         """
 
         i = InitPacketPB(
-                from_bytes = None,
+            from_bytes = None,
 
-                 hash_bytes = b"",
-                 hash_type = HashTypes.SHA256,
-                 dfu_type = DFUType.APPLICATION,
-                 is_debug=False,
-                 fw_version=0xffffffff,
-                 hw_version=0xffffffff,
-                 sd_size=0,
-                 app_size=1234,
-                 bl_size=0,
-                 sd_req=[0xffffffff]
-                )
+            hash_bytes = b"",
+            hash_type = HashTypes.SHA256,
+            dfu_type = DFUType.APPLICATION,
+            is_debug=False,
+            fw_version=0xffffffff,
+            hw_version=0xffffffff,
+            sd_size=0,
+            app_size=1234,
+            bl_size=0,
+            sd_req=[0xffffffff]
+            )
 
         i.set_signature(b"signature bytes go here", SigningTypes.ECDSA_P256_SHA256)
 
         protobuf_bytes = i.get_init_packet_pb_bytes(); # Bytes for the whole Packet
         hex_bytes = protobuf_bytes.encode('hex_codec');
 
-        self.assertEqual(hex_bytes, "12450a280801122408ffffffff0f10ffffffff0f1a" "05ffffffff0f20002800300038d209420408031200480010001a177369676e61747572"
+        self.assertEqual(hex_bytes, "12450a280801122408ffffffff0f10ffffffff0f1a"
+        "05ffffffff0f20002800300038d209420408031200480010001a177369676e61747572"
         "6520627974657320676f2068657265")
 
 
@@ -113,19 +94,19 @@ class TestStringMethods(unittest.TestCase):
         """
 
         i = InitPacketPB(
-                from_bytes = None,
+            from_bytes = None,
 
-                 hash_bytes = b"",
-                 hash_type = HashTypes.SHA256,
-                 dfu_type = DFUType.APPLICATION,
-                 is_debug=False,
-                 fw_version=0xffffffff,
-                 hw_version=0xffffffff,
-                 sd_size=0,
-                 app_size=1234,
-                 bl_size=0,
-                 sd_req=[0xffffffff]
-                )
+            hash_bytes = b"",
+            hash_type = HashTypes.SHA256,
+            dfu_type = DFUType.APPLICATION,
+            is_debug=False,
+            fw_version=0xffffffff,
+            hw_version=0xffffffff,
+            sd_size=0,
+            app_size=1234,
+            bl_size=0,
+            sd_req=[0xffffffff]
+            )
 
         protobuf_bytes = i.get_init_packet_pb_bytes(); # Bytes for the whole Packet
         hex_bytes = protobuf_bytes.encode('hex_codec');


### PR DESCRIPTION
TL;DR: users can create zip files without signing them

long version:
- Unit tests for the low-ish level protobuf funcionality (ensure that previous functionality is maintained)
- Allow for low-ish level instantiation of init packets protobufs with no signature
- Stop high-ish functionality (argument parser) from requiring a `--key` option
- `nrfutil pkg display` can deal with both signed and unsigned init packet protobufs
- Hook all the previous bits together
- Some minor changes and typo fixes on help strings