### PR TITLE
Allow customizing delay between DFU connections

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -652,7 +652,7 @@ def dfu():
     """
     pass
 
-def do_serial(package, port, flow_control, packet_receipt_notification, baud_rate, ping):
+def do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, ping):
 
     if flow_control is None:
         flow_control = DfuTransportSerial.DEFAULT_FLOW_CONTROL
@@ -667,7 +667,7 @@ def do_serial(package, port, flow_control, packet_receipt_notification, baud_rat
     serial_backend = DfuTransportSerial(com_port=str(port), baud_rate=baud_rate,
                     flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping)
     serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
-    dfu = Dfu(zip_file_path = package, dfu_transport = serial_backend)
+    dfu = Dfu(zip_file_path = package, dfu_transport = serial_backend, connect_delay = connect_delay)
 
     if logger.getEffectiveLevel() > logging.INFO:
         with click.progressbar(length=dfu.dfu_get_total_size()) as bar:
@@ -688,6 +688,10 @@ def do_serial(package, port, flow_control, packet_receipt_notification, baud_rat
               help='Serial port address to which the device is connected. (e.g. COM1 in windows systems, /dev/ttyACM0 in linux/mac)',
               type=click.STRING,
               required=True)
+@click.option('-cd', '--connect-delay',
+              help='Delay in seconds before each connection to the target device during DFU. Default is 3.',
+              type=click.INT,
+              required=False)
 @click.option('-fc', '--flow-control',
               help='To enable flow control set this flag to 1',
               type=click.BOOL,
@@ -700,10 +704,10 @@ def do_serial(package, port, flow_control, packet_receipt_notification, baud_rat
               help='Set the baud rate',
               type=click.INT,
               required=False)
-def usb_serial(package, port, flow_control, packet_receipt_notification, baud_rate):
+def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate):
     """Perform a Device Firmware Update on a device with a bootloader that supports USB serial DFU."""
 
-    do_serial(package, port, flow_control, packet_receipt_notification, baud_rate, False)
+    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, False)
 
 
 @dfu.command(short_help="Update the firmware on a device over a UART serial connection. The DFU target must be a chip using digital I/O pins as an UART.")
@@ -715,6 +719,10 @@ def usb_serial(package, port, flow_control, packet_receipt_notification, baud_ra
               help='Serial port address to which the device is connected. (e.g. COM1 in windows systems, /dev/ttyACM0 in linux/mac)',
               type=click.STRING,
               required=True)
+@click.option('-cd', '--connect-delay',
+              help='Delay in seconds before each connection to the target device during DFU. Default is 3.',
+              type=click.INT,
+              required=False)
 @click.option('-fc', '--flow-control',
               help='To enable flow control set this flag to 1',
               type=click.BOOL,
@@ -727,10 +735,10 @@ def usb_serial(package, port, flow_control, packet_receipt_notification, baud_ra
               help='Set the baud rate',
               type=click.INT,
               required=False)
-def serial(package, port, flow_control, packet_receipt_notification, baud_rate):
+def serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate):
     """Perform a Device Firmware Update on a device with a bootloader that supports UART serial DFU."""
 
-    do_serial(package, port, flow_control, packet_receipt_notification, baud_rate, True)
+    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, True)
 
 
 def enumerate_ports():
@@ -764,6 +772,10 @@ def get_port_by_snr(snr):
 @click.option('-p', '--port',
               help='Serial port COM port to which the connectivity IC is connected.',
               type=click.STRING)
+@click.option('-cd', '--connect-delay',
+              help='Delay in seconds before each connection to the target device during DFU. Default is 3.',
+              type=click.INT,
+              required=False)
 @click.option('-n', '--name',
               help='Device name.',
               type=click.STRING)
@@ -777,7 +789,7 @@ def get_port_by_snr(snr):
               help='Flash connectivity firmware automatically. Default: disabled.',
               type=click.BOOL,
               is_flag=True)
-def ble(package, conn_ic_id, port, name, address, jlink_snr, flash_connectivity):
+def ble(package, conn_ic_id, port, connect_delay, name, address, jlink_snr, flash_connectivity):
     """
     Perform a Device Firmware Update on a device with a bootloader that supports BLE DFU.
     This requires a second nRF device, connected to this computer, with connectivity firmware
@@ -813,7 +825,7 @@ def ble(package, conn_ic_id, port, name, address, jlink_snr, flash_connectivity)
                                   target_device_name=str(name),
                                   target_device_addr=str(address))
     ble_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
-    dfu = Dfu(zip_file_path = package, dfu_transport = ble_backend)
+    dfu = Dfu(zip_file_path = package, dfu_transport = ble_backend, connect_delay = connect_delay)
 
     if logger.getEffectiveLevel() > logging.INFO:
         with click.progressbar(length=dfu.dfu_get_total_size()) as bar:

--- a/nordicsemi/dfu/dfu.py
+++ b/nordicsemi/dfu/dfu.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 class Dfu(object):
     """ Class to handle upload of a new hex image to the device. """
 
-    def __init__(self, zip_file_path, dfu_transport):
+    def __init__(self, zip_file_path, dfu_transport, connect_delay):
         """
         Initializes the dfu upgrade, unpacks zip and registers callbacks.
 
@@ -62,6 +62,8 @@ class Dfu(object):
         @type zip_file_path: str
         @param dfu_transport: Transport backend to use to upgrade
         @type dfu_transport: nordicsemi.dfu.dfu_transport.DfuTransport
+        @param connect_delay: Delay in seconds before each connection to the DFU target
+        @type connect_delay: int
         @return
         """
         self.temp_dir           = tempfile.mkdtemp(prefix="nrf_dfu_")
@@ -69,6 +71,11 @@ class Dfu(object):
         self.manifest           = Package.unpack_package(zip_file_path, self.unpacked_zip_path)
 
         self.dfu_transport      = dfu_transport
+
+        if connect_delay is not None:
+            self.connect_delay = connect_delay
+        else:
+            self.connect_delay = 3
 
     def __del__(self):
         """
@@ -79,7 +86,7 @@ class Dfu(object):
 
 
     def _dfu_send_image(self, firmware):
-        time.sleep(3)
+        time.sleep(self.connect_delay)
         self.dfu_transport.open()
 
         start_time = time.time()


### PR DESCRIPTION
All DFU implementations currently have a 3 second delay before connecting to the DFU target device. This delay is needed because the target needs some time to reboot after sending images.

There are, however, cases where this delay is too low or too high. Instead of keeping this as a hard-coded value, we now allow the user to pass a `--connect-delay <seconds>` parameter. If not specified, then it will default to 3 seconds.

With the current implementation, the delay is added before all connections during DFU, but I suspect that it is not strictly needed before the initial connection. We could put the delay between each call to `_dfu_send_image()` in `dfu_send_images()` in dfu.py instead. However, some people may have come to rely on the initial delay in their scripts, so it may be best to keep it for now.