### PR TITLE
Add options to configure serial update timeouts

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -656,7 +656,8 @@ def dfu():
     """
     pass
 
-def do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, ping):
+def do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, ping,
+              timeout, serial_timeout):
 
     if flow_control is None:
         flow_control = DfuTransportSerial.DEFAULT_FLOW_CONTROL
@@ -666,10 +667,15 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
         baud_rate = DfuTransportSerial.DEFAULT_BAUD_RATE
     if ping is None:
         ping = False
+    if timeout is None:
+        timeout = DfuTransportSerial.DEFAULT_TIMEOUT
+    if serial_timeout is None:
+        serial_timeout = DfuTransportSerial.DEFAULT_SERIAL_PORT_TIMEOUT
 
     logger.info("Using board at serial port: {}".format(port))
     serial_backend = DfuTransportSerial(com_port=str(port), baud_rate=baud_rate,
-                    flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping)
+                    flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping,
+                    timeout=timeout, serial_timeout=serial_timeout)
     serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
     dfu = Dfu(zip_file_path = package, dfu_transport = serial_backend, connect_delay = connect_delay)
 
@@ -711,7 +717,8 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
 def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate):
     """Perform a Device Firmware Update on a device with a bootloader that supports USB serial DFU."""
 
-    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, False)
+    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, False,
+              None, None)
 
 
 @dfu.command(short_help="Update the firmware on a device over a UART serial connection. The DFU target must be a chip using digital I/O pins as an UART.")
@@ -739,10 +746,20 @@ def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notifi
               help='Set the baud rate',
               type=click.INT,
               required=False)
-def serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate):
+@click.option('-t', '--timeout',
+              help='Set the timeout in seconds for board to respond (default: 30 seconds)',
+              type=click.INT,
+              required=False)
+@click.option('-st', '--serial-timeout',
+              help='Set the timeout in seconds for the serial line (default: 1 second)',
+              type=click.FLOAT,
+              required=False)
+def serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate,
+           timeout, serial_timeout):
     """Perform a Device Firmware Update on a device with a bootloader that supports UART serial DFU."""
 
-    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, True)
+    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, True,
+              timeout, serial_timeout)
 
 
 def enumerate_ports():

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -147,6 +147,7 @@ class DfuTransportSerial(DfuTransport):
 
     DEFAULT_BAUD_RATE = 115200
     DEFAULT_FLOW_CONTROL = True
+    DEFAULT_TIMEOUT = 30.0  # Timeout time for board response
     DEFAULT_SERIAL_PORT_TIMEOUT = 1.0  # Timeout time on serial port read
     DEFAULT_PRN                 = 0
     DEFAULT_DO_PING = True
@@ -168,7 +169,8 @@ class DfuTransportSerial(DfuTransport):
                  com_port,
                  baud_rate=DEFAULT_BAUD_RATE,
                  flow_control=DEFAULT_FLOW_CONTROL,
-                 timeout=DEFAULT_SERIAL_PORT_TIMEOUT,
+                 timeout=DEFAULT_TIMEOUT,
+                 serial_timeout=DEFAULT_SERIAL_PORT_TIMEOUT,
                  prn=DEFAULT_PRN,
                  do_ping=DEFAULT_DO_PING):
 
@@ -177,6 +179,7 @@ class DfuTransportSerial(DfuTransport):
         self.baud_rate = baud_rate
         self.flow_control = 1 if flow_control else 0
         self.timeout = timeout
+        self.serial_timeout = serial_timeout
         self.prn         = prn
         self.serial_port = None
         self.dfu_adapter = None
@@ -193,7 +196,7 @@ class DfuTransportSerial(DfuTransport):
 
         try:
             self.serial_port = Serial(port=self.com_port,
-                baudrate=self.baud_rate, rtscts=self.flow_control, timeout=self.timeout)
+                baudrate=self.baud_rate, rtscts=self.flow_control, timeout=self.serial_timeout)
             self.dfu_adapter = DFUAdapter(self.serial_port)
         except Exception as e:
             raise NordicSemiException("Serial port could not be opened on {0}"

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -202,7 +202,8 @@ class DfuTransportSerial(DfuTransport):
         if self.do_ping:
             ping_success = False
             start = datetime.now()
-            while datetime.now() - start < timedelta(seconds=self.timeout):
+            while (datetime.now() - start < timedelta(seconds=self.timeout)
+                    and ping_success == False):
                 if self.__ping() == True:
                     ping_success = True
 

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -205,7 +205,6 @@ class DfuTransportSerial(DfuTransport):
             while datetime.now() - start < timedelta(seconds=self.timeout):
                 if self.__ping() == True:
                     ping_success = True
-                time.sleep(1)
 
             if ping_success == False:
                 raise NordicSemiException("No ping response after opening COM port")


### PR DESCRIPTION
This branch mainly add option to configure the serial UART update timeout values. In my application, the only way to update the firmware is to reset the board and trigger the update during the bootloader stage. As I have set a short inactivity timer for dfu to ensure quick boot (200 ms), I had to modify the nrfutil to wait a longer time for board to be ready and to reduce the ping interval, that's why i add the option to configure these timeout.

Please note that I only add these options to the UART update method and not for the USB serial as the latter doesn't ping the target.

Feel free to comment.