### PR TITLE
Python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ pip install -r requirements.txt
 
 You can run the program directly without installing it by executing:
 ```
-python nordicsemi/__main__.py
+python2 nordicsemi/__main__.py
 ```
 
 ### Installing from source
 
 To install the library to the local Python site-packages and script folder:  
 ```
-python setup.py install
+python2 setup.py install
 ```
 
 To generate a self-contained executable version of the utility:  

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2016 Nordic Semiconductor ASA
 # All rights reserved.
@@ -39,7 +39,7 @@
 Setup script for nrfutil.
 
 USAGE:
-    python setup.py install
+    python2 setup.py install
 
 """
 import os


### PR DESCRIPTION
Since only Python 2 is supported, it is better to reference Python 2 explicitly.
Not sure if all changes are desired - let me know when something needs to be reverted.