### PR TITLE
Specify required version for protobuf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ enum34 >= 1.0.4
 click >= 6.0
 ecdsa >= 0.13
 behave
-protobuf
+protobuf >= 3.6
 pc_ble_driver_py >= 0.11.4
 tqdm
 piccata


### PR DESCRIPTION
nrfutil requires protobuf version >= 3.6 to run correctly