### PR TITLE
Change uart connect timeout

### DIFF
--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -353,9 +353,9 @@ class DfuTransportSerial(DfuTransport):
             return False
 
         #  Return true if nrf bootloader or Jlink interface detected.
-        return (device.vendor_id.lower() == '1915' and device.product_id.lower() == '521f')  \
-            or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '0105')  \
-            or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '1015')
+        return ((device.vendor_id.lower() == '1915' and device.product_id.lower() == '521f') # nRF52 SDFU USB
+             or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '0105') # JLink CDC UART Port
+             or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '1015'))# JLink CSC UART Port (MSD)
 
     def __set_prn(self):
         logger.debug("Serial: Set Packet Receipt Notification {}".format(self.prn))

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -149,6 +149,7 @@ class DfuTransportSerial(DfuTransport):
 
     DEFAULT_BAUD_RATE = 115200
     DEFAULT_FLOW_CONTROL = True
+    DEFAULT_SERIAL_PORT_CONNECT_TIMEOUT = 15.0
     DEFAULT_SERIAL_PORT_TIMEOUT = 1.0  # Timeout time on serial port read
     DEFAULT_PRN                 = 0
     DEFAULT_DO_PING = True
@@ -204,9 +205,10 @@ class DfuTransportSerial(DfuTransport):
         if self.do_ping:
             ping_success = False
             start = datetime.now()
-            while datetime.now() - start < timedelta(seconds=self.timeout):
+            while datetime.now() - start < timedelta(seconds=self.DEFAULT_SERIAL_PORT_CONNECT_TIMEOUT):
                 if self.__ping() == True:
                     ping_success = True
+                    break
                 time.sleep(1)
 
             if ping_success == False:
@@ -306,7 +308,15 @@ class DfuTransportSerial(DfuTransport):
 
     def __ensure_bootloader(self):
         lister = DeviceLister()
-        device = lister.get_device(com=self.com_port)
+        device = None
+
+        start = datetime.now()
+        while datetime.now() - start < timedelta(seconds=self.DEFAULT_SERIAL_PORT_CONNECT_TIMEOUT):
+            device = lister.get_device(com=self.com_port)
+            if device:
+                break
+            time.sleep(0.05)
+
         if device:
             device_serial_number = device.serial_number
 

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -354,8 +354,8 @@ class DfuTransportSerial(DfuTransport):
 
         #  Return true if nrf bootloader or Jlink interface detected.
         return (device.vendor_id.lower() == '1915' and device.product_id.lower() == '521f')  \
-        or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '0105')
-
+            or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '0105')  \
+            or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '1015')
 
     def __set_prn(self):
         logger.debug("Serial: Set Packet Receipt Notification {}".format(self.prn))


### PR DESCRIPTION
When doing a SD+BL+APP update, the worst case for the chip to apply the SD+BL update and be ready for the application update can be around 13 seconds, which causes the current implementation to time out as either the USB COM port is not up and running, or the UART bootloader does not reply to the ping. This PR adds a timeout loop for finding the COM port, giving the USB bootloader time to set up the COM port, and extends the current ping-response timeout giving the UART bootloader time to respond. Both timeout loops should exit as soon as a COM port is found or ping response is received.

Also added USB PID for pca10056 in __ensure_bootloader(), so that using UART DFU with pca10056 does not enter the trigger code.