### PR TITLE
Change uart connect timeout

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -919,7 +919,7 @@ def dfu():
     pass
 
 def do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, ping,
-              timeout, serial_timeout):
+              timeout):
 
     if flow_control is None:
         flow_control = DfuTransportSerial.DEFAULT_FLOW_CONTROL
@@ -939,13 +939,11 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
 
     if timeout is None:
         timeout = DfuTransportSerial.DEFAULT_TIMEOUT
-    if serial_timeout is None:
-        serial_timeout = DfuTransportSerial.DEFAULT_SERIAL_PORT_TIMEOUT
 
     logger.info("Using board at serial port: {}".format(port))
     serial_backend = DfuTransportSerial(com_port=str(port), baud_rate=baud_rate,
                                         flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping,
-                                        timeout=timeout, serial_timeout=serial_timeout)
+                                        timeout=timeout)
     serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
     dfu = Dfu(zip_file_path = package, dfu_transport = serial_backend, connect_delay = connect_delay)
 
@@ -994,15 +992,11 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
               help='Set the timeout in seconds for board to respond (default: 30 seconds)',
               type=click.INT,
               required=False)
-@click.option('-st', '--serial-timeout',
-              help='Set the timeout in seconds for the serial line (default: 1 second)',
-              type=click.FLOAT,
-              required=False)
 def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number,
-               timeout, serial_timeout):
+               timeout):
     """Perform a Device Firmware Update on a device with a bootloader that supports USB serial DFU."""
     do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, False,
-              timeout, serial_timeout)
+              timeout)
 
 
 @dfu.command(short_help="Update the firmware on a device over a UART serial connection. The DFU target must be a chip using digital I/O pins as an UART.")
@@ -1038,16 +1032,12 @@ def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notifi
               help='Set the timeout in seconds for board to respond (default: 30 seconds)',
               type=click.INT,
               required=False)
-@click.option('-st', '--serial-timeout',
-              help='Set the timeout in seconds for the serial line (default: 1 second)',
-              type=click.FLOAT,
-              required=False)
 def serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number,
-           timeout, serial_timeout):
+           timeout):
     """Perform a Device Firmware Update on a device with a bootloader that supports UART serial DFU."""
 
     do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, True,
-              timeout, serial_timeout)
+              timeout)
 
 
 def enumerate_ports():

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -918,7 +918,8 @@ def dfu():
     """
     pass
 
-def do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, ping):
+def do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, ping,
+              timeout, serial_timeout):
 
     if flow_control is None:
         flow_control = DfuTransportSerial.DEFAULT_FLOW_CONTROL
@@ -943,7 +944,8 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
 
     logger.info("Using board at serial port: {}".format(port))
     serial_backend = DfuTransportSerial(com_port=str(port), baud_rate=baud_rate,
-                    flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping)
+                                        flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping,
+                                        timeout=timeout, serial_timeout=serial_timeout)
     serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
     dfu = Dfu(zip_file_path = package, dfu_transport = serial_backend, connect_delay = connect_delay)
 
@@ -988,9 +990,19 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
               help='Serial number of the device. Ignored if --port is set.',
               type=click.STRING,
               required=False)
-def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number):
+@click.option('-t', '--timeout',
+              help='Set the timeout in seconds for board to respond (default: 30 seconds)',
+              type=click.INT,
+              required=False)
+@click.option('-st', '--serial-timeout',
+              help='Set the timeout in seconds for the serial line (default: 1 second)',
+              type=click.FLOAT,
+              required=False)
+def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number,
+               timeout, serial_timeout):
     """Perform a Device Firmware Update on a device with a bootloader that supports USB serial DFU."""
-    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, False)
+    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, False,
+              timeout, serial_timeout)
 
 
 @dfu.command(short_help="Update the firmware on a device over a UART serial connection. The DFU target must be a chip using digital I/O pins as an UART.")
@@ -1034,7 +1046,8 @@ def serial(package, port, connect_delay, flow_control, packet_receipt_notificati
            timeout, serial_timeout):
     """Perform a Device Firmware Update on a device with a bootloader that supports UART serial DFU."""
 
-    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, True)
+    do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, True,
+              timeout, serial_timeout)
 
 
 def enumerate_ports():

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -172,7 +172,6 @@ class DfuTransportSerial(DfuTransport):
                  baud_rate=DEFAULT_BAUD_RATE,
                  flow_control=DEFAULT_FLOW_CONTROL,
                  timeout=DEFAULT_TIMEOUT,
-                 serial_timeout=DEFAULT_SERIAL_PORT_TIMEOUT,
                  prn=DEFAULT_PRN,
                  do_ping=DEFAULT_DO_PING):
 
@@ -181,7 +180,6 @@ class DfuTransportSerial(DfuTransport):
         self.baud_rate = baud_rate
         self.flow_control = 1 if flow_control else 0
         self.timeout = timeout
-        self.serial_timeout = serial_timeout
         self.prn         = prn
         self.serial_port = None
         self.dfu_adapter = None
@@ -198,7 +196,7 @@ class DfuTransportSerial(DfuTransport):
         try:
             self.__ensure_bootloader()
             self.serial_port = Serial(port=self.com_port,
-                baudrate=self.baud_rate, rtscts=self.flow_control, timeout=self.serial_timeout)
+                baudrate=self.baud_rate, rtscts=self.flow_control, timeout=self.DEFAULT_SERIAL_PORT_TIMEOUT)
             self.dfu_adapter = DFUAdapter(self.serial_port)
         except Exception as e:
             raise NordicSemiException("Serial port could not be opened on {0}"


### PR DESCRIPTION
When doing a SD+BL+APP update, the worst case for the chip to apply the SD+BL update and be ready for the application update can be around 13 seconds, which causes the current implementation to time out as either the USB COM port is not up and running, or the UART bootloader does not reply to the ping. This PR adds a timeout loop for finding the COM port, giving the USB bootloader time to set up the COM port.

Also added USB PID for pca10056 configured as a Mass Storage Device (MSD) in __ensure_bootloader(), so that using UART DFU with pca10056 MSD does not enter the USBTrigger code.

(This PR replaces #198 )