### PR TITLE
Better IO error message reporting.

### DIFF
--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -200,7 +200,7 @@ class DfuTransportSerial(DfuTransport):
             self.dfu_adapter = DFUAdapter(self.serial_port)
         except Exception as e:
             raise NordicSemiException("Serial port could not be opened on {0}"
-            + ". Reason: {1}".format(self.com_port, e.strerror))
+              ". Reason: {1}".format(self.com_port, e.strerror))
 
         if self.do_ping:
             ping_success = False

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -200,7 +200,7 @@ class DfuTransportSerial(DfuTransport):
             self.dfu_adapter = DFUAdapter(self.serial_port)
         except Exception as e:
             raise NordicSemiException("Serial port could not be opened on {0}"
-            + ". Reason: {1}".format(self.com_port, e.message))
+            + ". Reason: {1}".format(self.com_port, e.strerror))
 
         if self.do_ping:
             ping_success = False


### PR DESCRIPTION
.message is empty when IOError is constructed with two argmuments, like pyserial always does.  (The first arg is errno.)

e.g., 
```
>>> IOError('test').message
'test'
>>> IOError(5, 'test').message
''

```