### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ pyspinel == 1.0.0a3
 intelhex ~= 2.2
 pyyaml ~= 4.2b1
 crcmod ~= 1.7
-antlib ~= 1.0b ; sys_platform == 'win32'
 libusb1 ~= 1.7


### PR DESCRIPTION
The pip requirements file syntax is not able to specify the requirement of Windows 32 bit Python, which is the only supported variant of antlib currently. Removing the entry from the requirements file as a workaround, and instead relying on manual installation of antlib.

Closes #210 and closes #213.