### PR TITLE
Feature/convert to py3

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -1066,7 +1066,7 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
               type=click.INT,
               required=False)
 @click.option('-d', '--debug/--no-debug',
-              help='Enable ANT debug logs.',
+              help='Enable Serial debug logs.',
               default=False,
               required=False)
 def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number,

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -34,18 +34,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-import spinel.util as util
-from nordicsemi.lister.device_lister import DeviceLister
-from pc_ble_driver_py.exceptions import NordicSemiException, NotImplementedException
-from nordicsemi.zigbee.prod_config import ProductionConfig, ProductionConfigWrongException, ProductionConfigTooLargeException
-from nordicsemi.dfu.util import query_func
-from nordicsemi.dfu.signing import Signing
-from nordicsemi import version as nrfutil_version
-from nordicsemi.dfu.package import Package
-from nordicsemi.dfu.dfu_transport_serial import DfuTransportSerial
-from nordicsemi.dfu.dfu_transport import DfuEvent, TRANSPORT_LOGGING_LEVEL
-from nordicsemi.dfu.dfu import Dfu
 from nordicsemi.dfu.bl_dfu_sett import BLDFUSettings
+from nordicsemi.dfu.dfu import Dfu
+from nordicsemi.dfu.dfu_transport import DfuEvent, TRANSPORT_LOGGING_LEVEL
+from nordicsemi.dfu.dfu_transport_serial import DfuTransportSerial
+from nordicsemi.dfu.package import Package
+from nordicsemi import version as nrfutil_version
+from nordicsemi.dfu.signing import Signing
+from nordicsemi.dfu.util import query_func
+from nordicsemi.zigbee.prod_config import ProductionConfig, ProductionConfigWrongException, ProductionConfigTooLargeException
+from pc_ble_driver_py.exceptions import NordicSemiException, NotImplementedException
+from nordicsemi.lister.device_lister import DeviceLister
+import spinel.util as util
 import ipaddress
 import signal
 
@@ -990,7 +990,7 @@ def dfu():
 
 
 def do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, ping,
-              timeout, debug):
+              timeout):
 
     if flow_control is None:
         flow_control = DfuTransportSerial.DEFAULT_FLOW_CONTROL
@@ -1015,7 +1015,7 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
     logger.info("Using board at serial port: {}".format(port))
     serial_backend = DfuTransportSerial(com_port=str(port), baud_rate=baud_rate,
                                         flow_control=flow_control, prn=packet_receipt_notification, do_ping=ping,
-                                        timeout=timeout, debug=debug)
+                                        timeout=timeout)
     serial_backend.register_events_callback(DfuEvent.PROGRESS_EVENT, update_progress)
     dfu = Dfu(zip_file_path=package, dfu_transport=serial_backend, connect_delay=connect_delay)
 
@@ -1065,15 +1065,11 @@ def do_serial(package, port, connect_delay, flow_control, packet_receipt_notific
               help='Set the timeout in seconds for board to respond (default: 30 seconds)',
               type=click.INT,
               required=False)
-@click.option('-d', '--debug/--no-debug',
-              help='Enable Serial debug logs.',
-              default=False,
-              required=False)
 def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number,
-               timeout, debug):
+               timeout):
     """Perform a Device Firmware Update on a device with a bootloader that supports USB serial DFU."""
     do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, False,
-              timeout, debug)
+              timeout)
 
 
 @dfu.command(short_help="Update the firmware on a device over a UART serial connection. The DFU target must be a chip using digital I/O pins as an UART.")
@@ -1109,16 +1105,12 @@ def usb_serial(package, port, connect_delay, flow_control, packet_receipt_notifi
               help='Set the timeout in seconds for board to respond (default: 30 seconds)',
               type=click.INT,
               required=False)
-@click.option('-d', '--debug/--no-debug',
-              help='Enable ANT debug logs.',
-              default=False,
-              required=False)
 def serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number,
-           timeout, debug):
+           timeout):
     """Perform a Device Firmware Update on a device with a bootloader that supports UART serial DFU."""
 
     do_serial(package, port, connect_delay, flow_control, packet_receipt_notification, baud_rate, serial_number, True,
-              timeout, debug)
+              timeout)
 
 
 def enumerate_ports():

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -47,10 +47,11 @@ from serial import Serial
 from serial.serialutil import SerialException
 
 # Nordic Semiconductor imports
-from nordicsemi.dfu.dfu_transport   import DfuTransport, DfuEvent, TRANSPORT_LOGGING_LEVEL
-from pc_ble_driver_py.exceptions    import NordicSemiException, IllegalStateException
+from nordicsemi.dfu.dfu_transport import DfuTransport, DfuEvent, TRANSPORT_LOGGING_LEVEL
+from pc_ble_driver_py.exceptions import NordicSemiException, IllegalStateException
 from nordicsemi.lister.device_lister import DeviceLister
 from nordicsemi.dfu.dfu_trigger import DFUTrigger
+
 
 class ValidationException(NordicSemiException):
     """"
@@ -61,15 +62,16 @@ class ValidationException(NordicSemiException):
 
 logger = logging.getLogger(__name__)
 
-class Slip(object):
-    SLIP_BYTE_END             = 0o300
-    SLIP_BYTE_ESC             = 0o333
-    SLIP_BYTE_ESC_END         = 0o334
-    SLIP_BYTE_ESC_ESC         = 0o335
 
-    SLIP_STATE_DECODING                 = 1
-    SLIP_STATE_ESC_RECEIVED             = 2
-    SLIP_STATE_CLEARING_INVALID_PACKET  = 3
+class Slip(object):
+    SLIP_BYTE_END = 0o300
+    SLIP_BYTE_ESC = 0o333
+    SLIP_BYTE_ESC_END = 0o334
+    SLIP_BYTE_ESC_ESC = 0o335
+
+    SLIP_STATE_DECODING = 1
+    SLIP_STATE_ESC_RECEIVED = 2
+    SLIP_STATE_CLEARING_INVALID_PACKET = 3
 
     @staticmethod
     def encode(data):
@@ -112,6 +114,7 @@ class Slip(object):
 
         return (finished, current_state, decoded_data)
 
+
 class DFUAdapter(object):
     def __init__(self, serial_port):
         self.serial_port = serial_port
@@ -136,7 +139,7 @@ class DFUAdapter(object):
             if byte:
                 (byte) = struct.unpack('B', byte)[0]
                 (finished, current_state, decoded_data) \
-                   = Slip.decode_add_byte(byte, decoded_data, current_state)
+                    = Slip.decode_add_byte(byte, decoded_data, current_state)
             else:
                 current_state = Slip.SLIP_STATE_CLEARING_INVALID_PACKET
                 return None
@@ -145,26 +148,27 @@ class DFUAdapter(object):
 
         return decoded_data
 
+
 class DfuTransportSerial(DfuTransport):
 
     DEFAULT_BAUD_RATE = 115200
     DEFAULT_FLOW_CONTROL = True
     DEFAULT_TIMEOUT = 30.0  # Timeout time for board response
     DEFAULT_SERIAL_PORT_TIMEOUT = 1.0  # Timeout time on serial port read
-    DEFAULT_PRN                 = 0
+    DEFAULT_PRN = 0
     DEFAULT_DO_PING = True
 
     OP_CODE = {
-        'CreateObject'          : 0x01,
-        'SetPRN'                : 0x02,
-        'CalcChecSum'           : 0x03,
-        'Execute'               : 0x04,
-        'ReadError'             : 0x05,
-        'ReadObject'            : 0x06,
-        'GetSerialMTU'          : 0x07,
-        'WriteObject'           : 0x08,
-        'Ping'                  : 0x09,
-        'Response'              : 0x60,
+        'CreateObject': 0x01,
+        'SetPRN': 0x02,
+        'CalcChecSum': 0x03,
+        'Execute': 0x04,
+        'ReadError': 0x05,
+        'ReadObject': 0x06,
+        'GetSerialMTU': 0x07,
+        'WriteObject': 0x08,
+        'Ping': 0x09,
+        'Response': 0x60,
     }
 
     def __init__(self,
@@ -180,27 +184,26 @@ class DfuTransportSerial(DfuTransport):
         self.baud_rate = baud_rate
         self.flow_control = 1 if flow_control else 0
         self.timeout = timeout
-        self.prn         = prn
+        self.prn = prn
         self.serial_port = None
         self.dfu_adapter = None
-        self.ping_id     = 0
-        self.do_ping     = do_ping
+        self.ping_id = 0
+        self.do_ping = do_ping
 
-        self.mtu         = 0
+        self.mtu = 0
 
         """:type: serial.Serial """
-
 
     def open(self):
         super(DfuTransportSerial, self).open()
         try:
             self.__ensure_bootloader()
             self.serial_port = Serial(port=self.com_port,
-                baudrate=self.baud_rate, rtscts=self.flow_control, timeout=self.DEFAULT_SERIAL_PORT_TIMEOUT)
+                                      baudrate=self.baud_rate, rtscts=self.flow_control, timeout=self.DEFAULT_SERIAL_PORT_TIMEOUT)
             self.dfu_adapter = DFUAdapter(self.serial_port)
         except Exception as e:
             raise NordicSemiException("Serial port could not be opened on {0}"
-              ". Reason: {1}".format(self.com_port, e.strerror))
+                                      ". Reason: {1}".format(self.com_port, e.strerror))
 
         if self.do_ping:
             ping_success = False
@@ -235,9 +238,9 @@ class DfuTransportSerial(DfuTransport):
             if len(init_packet) > response['offset']:
                 # Send missing part.
                 try:
-                    self.__stream_data(data     = init_packet[response['offset']:],
-                                       crc      = expected_crc,
-                                       offset   = response['offset'])
+                    self.__stream_data(data=init_packet[response['offset']:],
+                                       crc=expected_crc,
+                                       offset=response['offset'])
                 except ValidationException:
                     return False
 
@@ -264,28 +267,28 @@ class DfuTransportSerial(DfuTransport):
                 return
 
             expected_crc = binascii.crc32(firmware[:response['offset']]) & 0xFFFFFFFF
-            remainder    = response['offset'] % response['max_size']
+            remainder = response['offset'] % response['max_size']
 
             if expected_crc != response['crc']:
                 # Invalid CRC. Remove corrupted data.
                 response['offset'] -= remainder if remainder != 0 else response['max_size']
-                response['crc']     = \
-                        binascii.crc32(firmware[:response['offset']]) & 0xFFFFFFFF
+                response['crc'] = \
+                    binascii.crc32(firmware[:response['offset']]) & 0xFFFFFFFF
                 return
 
             if (remainder != 0) and (response['offset'] != len(firmware)):
                 # Send rest of the page.
                 try:
-                    to_send             = firmware[response['offset'] : response['offset']
-                                                + response['max_size'] - remainder]
-                    response['crc']     = self.__stream_data(data   = to_send,
-                                                             crc    = response['crc'],
-                                                             offset = response['offset'])
+                    to_send = firmware[response['offset']: response['offset']
+                                       + response['max_size'] - remainder]
+                    response['crc'] = self.__stream_data(data=to_send,
+                                                         crc=response['crc'],
+                                                         offset=response['offset'])
                     response['offset'] += len(to_send)
                 except ValidationException:
                     # Remove corrupted data.
                     response['offset'] -= remainder
-                    response['crc']     = \
+                    response['crc'] = \
                         binascii.crc32(firmware[:response['offset']]) & 0xFFFFFFFF
                     return
 
@@ -328,10 +331,9 @@ class DfuTransportSerial(DfuTransport):
                 except NordicSemiException as err:
                     logger.error(err)
 
-
                 for checks in range(retry_count):
-                    logger.info("Serial: Waiting {} ms for device to enter bootloader {}/{} time"\
-                    .format(500, checks + 1, retry_count))
+                    logger.info("Serial: Waiting {} ms for device to enter bootloader {}/{} time"
+                                .format(500, checks + 1, retry_count))
 
                     time.sleep(wait_time_ms / 1000.0)
 
@@ -342,34 +344,35 @@ class DfuTransportSerial(DfuTransport):
 
                 trigger.clean()
             if not self.__is_device_in_bootloader_mode(device):
-                logger.info("Serial: Device is either not in bootloader mode, or using an unsupported bootloader.")
+                logger.info(
+                    "Serial: Device is either not in bootloader mode, or using an unsupported bootloader.")
 
     def __is_device_in_bootloader_mode(self, device):
         if not device:
             return False
 
         #  Return true if nrf bootloader or Jlink interface detected.
-        return ((device.vendor_id.lower() == '1915' and device.product_id.lower() == '521f') # nRF52 SDFU USB
-             or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '0105') # JLink CDC UART Port
-             or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '1015'))# JLink CDC UART Port (MSD)
+        return ((device.vendor_id.lower() == '1915' and device.product_id.lower() == '521f')  # nRF52 SDFU USB
+                # JLink CDC UART Port
+                or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '0105')
+                or (device.vendor_id.lower() == '1366' and device.product_id.lower() == '1015'))  # JLink CDC UART Port (MSD)
 
     def __set_prn(self):
         logger.debug("Serial: Set Packet Receipt Notification {}".format(self.prn))
         self.dfu_adapter.send_message([DfuTransportSerial.OP_CODE['SetPRN']]
-            + list(map(ord, struct.pack('<H', self.prn))))
+                                      + list(struct.pack('<H', self.prn)))
         self.__get_response(DfuTransportSerial.OP_CODE['SetPRN'])
 
     def __get_mtu(self):
         self.dfu_adapter.send_message([DfuTransportSerial.OP_CODE['GetSerialMTU']])
         response = self.__get_response(DfuTransportSerial.OP_CODE['GetSerialMTU'])
-
-        self.mtu = struct.unpack('<H', bytearray(response))[0]
+        self.mtu = int(struct.unpack('<H', bytearray(response))[0])
 
     def __ping(self):
         self.ping_id = (self.ping_id + 1) % 256
 
         self.dfu_adapter.send_message([DfuTransportSerial.OP_CODE['Ping'], self.ping_id])
-        resp = self.dfu_adapter.get_message() # Receive raw reponse to check return code
+        resp = self.dfu_adapter.get_message()  # Receive raw reponse to check return code
 
         if (resp == None):
             logger.debug('Serial: No ping response')
@@ -380,8 +383,8 @@ class DfuTransportSerial(DfuTransport):
             return False
 
         if resp[1] != DfuTransportSerial.OP_CODE['Ping']:
-            logger.debug('Serial: Unexpected Executed OP_CODE.\n' \
-                + 'Expected: 0x{:02X} Received: 0x{:02X}'.format(DfuTransportSerial.OP_CODE['Ping'], resp[1]))
+            logger.debug('Serial: Unexpected Executed OP_CODE.\n'
+                         + 'Expected: 0x{:02X} Received: 0x{:02X}'.format(DfuTransportSerial.OP_CODE['Ping'], resp[1]))
             return False
 
         if resp[2] != DfuTransport.RES_CODE['Success']:
@@ -400,8 +403,8 @@ class DfuTransportSerial(DfuTransport):
         self.__create_object(0x02, size)
 
     def __create_object(self, object_type, size):
-        self.dfu_adapter.send_message([DfuTransportSerial.OP_CODE['CreateObject'], object_type]\
-                                            + list(map(ord, struct.pack('<L', size))))
+        self.dfu_adapter.send_message([DfuTransportSerial.OP_CODE['CreateObject'], object_type]
+                                      + list(struct.pack('<L', size)))
         self.__get_response(DfuTransportSerial.OP_CODE['CreateObject'])
 
     def __calculate_checksum(self):
@@ -431,10 +434,10 @@ class DfuTransportSerial(DfuTransport):
         self.dfu_adapter.send_message([DfuTransportSerial.OP_CODE['ReadObject'], object_type])
 
         response = self.__get_response(DfuTransportSerial.OP_CODE['ReadObject'])
-        (max_size, offset, crc)= struct.unpack('<III', bytearray(response))
+        (max_size, offset, crc) = struct.unpack('<III', bytearray(response))
 
         logger.debug("Serial: Object selected: " +
-            " max_size:{} offset:{} crc:{}".format(max_size, offset, crc))
+                     " max_size:{} offset:{} crc:{}".format(max_size, offset, crc))
         return {'max_size': max_size, 'offset': offset, 'crc': crc}
 
     def __get_checksum_response(self):
@@ -445,31 +448,32 @@ class DfuTransportSerial(DfuTransport):
 
     def __stream_data(self, data, crc=0, offset=0):
         logger.debug("Serial: Streaming Data: " +
-            "len:{0} offset:{1} crc:0x{2:08X}".format(len(data), offset, crc))
+                     "len:{0} offset:{1} crc:0x{2:08X}".format(len(data), offset, crc))
+
         def validate_crc():
             if (crc != response['crc']):
-                raise ValidationException('Failed CRC validation.\n'\
-                                + 'Expected: {} Recieved: {}.'.format(crc, response['crc']))
+                raise ValidationException('Failed CRC validation.\n'
+                                          + 'Expected: {} Recieved: {}.'.format(crc, response['crc']))
             if (offset != response['offset']):
-                raise ValidationException('Failed offset validation.\n'\
-                                + 'Expected: {} Recieved: {}.'.format(offset, response['offset']))
+                raise ValidationException('Failed offset validation.\n'
+                                          + 'Expected: {} Recieved: {}.'.format(offset, response['offset']))
 
-        current_pnr     = 0
+        current_pnr = 0
 
-        for i in range(0, len(data), (self.mtu-1)/2 - 1):
+        for i in range(0, len(data), int((self.mtu-1)/2 - 1)):
             # append the write data opcode to the front
             # here the maximum data size is self.mtu/2,
             # due to the slip encoding which at maximum doubles the size
-            to_transmit = data[i:i + (self.mtu-1)/2 - 1 ]
-            to_transmit = struct.pack('B',DfuTransportSerial.OP_CODE['WriteObject']) + to_transmit
+            to_transmit = data[i:i + int((self.mtu-1)/2 - 1)]
+            to_transmit = struct.pack('B', DfuTransportSerial.OP_CODE['WriteObject']) + to_transmit
 
-            self.dfu_adapter.send_message(list(map(ord, to_transmit)))
-            crc     = binascii.crc32(to_transmit[1:], crc) & 0xFFFFFFFF
+            self.dfu_adapter.send_message(list(to_transmit))
+            crc = binascii.crc32(to_transmit[1:], crc) & 0xFFFFFFFF
             offset += len(to_transmit) - 1
-            current_pnr    += 1
+            current_pnr += 1
             if self.prn == current_pnr:
                 current_pnr = 0
-                response    = self.__get_checksum_response()
+                response = self.__get_checksum_response()
                 validate_crc()
         response = self.__calculate_checksum()
         validate_crc()
@@ -488,8 +492,8 @@ class DfuTransportSerial(DfuTransport):
             raise NordicSemiException('No Response: 0x{:02X}'.format(resp[0]))
 
         if resp[1] != operation:
-            raise NordicSemiException('Unexpected Executed OP_CODE.\n' \
-                             + 'Expected: 0x{:02X} Received: 0x{:02X}'.format(operation, resp[1]))
+            raise NordicSemiException('Unexpected Executed OP_CODE.\n'
+                                      + 'Expected: 0x{:02X} Received: 0x{:02X}'.format(operation, resp[1]))
 
         if resp[2] == DfuTransport.RES_CODE['Success']:
             return resp[3:]

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -178,7 +178,8 @@ class DfuTransportSerial(DfuTransport):
                  flow_control=DEFAULT_FLOW_CONTROL,
                  timeout=DEFAULT_TIMEOUT,
                  prn=DEFAULT_PRN,
-                 do_ping=DEFAULT_DO_PING):
+                 do_ping=DEFAULT_DO_PING,
+                 debug=DEFAULT_DO_DEBUG):
 
         super(DfuTransportSerial, self).__init__()
         self.com_port = com_port

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -178,8 +178,7 @@ class DfuTransportSerial(DfuTransport):
                  flow_control=DEFAULT_FLOW_CONTROL,
                  timeout=DEFAULT_TIMEOUT,
                  prn=DEFAULT_PRN,
-                 do_ping=DEFAULT_DO_PING,
-                 debug=DEFAULT_DO_DEBUG):
+                 do_ping=DEFAULT_DO_PING):
 
         super(DfuTransportSerial, self).__init__()
         self.com_port = com_port
@@ -191,12 +190,8 @@ class DfuTransportSerial(DfuTransport):
         self.dfu_adapter = None
         self.ping_id = 0
         self.do_ping = do_ping
-        self.debug = debug
 
         self.mtu = 0
-
-        if self.debug:
-            logger.setLevel(logging.DEBUG)
 
         """:type: serial.Serial """
 

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -157,6 +157,7 @@ class DfuTransportSerial(DfuTransport):
     DEFAULT_SERIAL_PORT_TIMEOUT = 1.0  # Timeout time on serial port read
     DEFAULT_PRN = 0
     DEFAULT_DO_PING = True
+    DEFAULT_DO_DEBUG = False
 
     OP_CODE = {
         'CreateObject': 0x01,
@@ -189,8 +190,12 @@ class DfuTransportSerial(DfuTransport):
         self.dfu_adapter = None
         self.ping_id = 0
         self.do_ping = do_ping
+        self.debug = debug
 
         self.mtu = 0
+
+        if self.debug:
+            logger.setLevel(logging.DEBUG)
 
         """:type: serial.Serial """
 


### PR DESCRIPTION
The current code in dfu_transport_serial.py is not working with python3, due to a miss use of the struct library.

**Added features:**
1. make dfu_transport_serial.py to work with python3
2. added debug mode for trasport_serial 

We testet the updated dfu serial transport on linux with python3 and it works flawlessly.
Even-though when we are flashing new code to the bootloader, we need a big custom timeout using the `--timout` flag. We are not sure why this is the case, but will investigate it further :)

Last but not least, we added a `--debug` flag, so users can read debug messages, if they want to know what is going. strangely `logging.debug(...)` is used, even though no one can read the messages :(

It took as  night to fix all the issues and make nrfutils work on our deployed devices at [apic.ai](https://apic.ai), so there might be further issues.
We love to contribute and will add further pull requests, if we change something :)