### PR TITLE
Update pyyaml requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ tqdm ~= 4.25
 piccata ~= 1.0
 pyspinel == 1.0.0a3
 intelhex ~= 2.2
-pyyaml ~= 4.2b1
+pyyaml >= 4.2b1
 crcmod ~= 1.7
 libusb1 ~= 1.7


### PR DESCRIPTION
The current requirement of pyyaml version is causing conflict with requirements of other dependencies. Loosening the requirement to mitigate this.