### PR TITLE
Remove nRFHex.tohexfile

### DIFF
--- a/nordicsemi/dfu/nrfhex.py
+++ b/nordicsemi/dfu/nrfhex.py
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2016 Nordic Semiconductor ASA
+# Copyright (c) 2016 - 2019 Nordic Semiconductor ASA
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -33,7 +32,6 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
 
 import intelhex
 from struct import unpack
@@ -84,9 +82,6 @@ class nRFHex(intelhex.IntelHex):
 
         if bootloader is not None:
             self.bootloaderhex = nRFHex(bootloader)
-
-    def tohexfile(self, dest):
-        pass
 
     def _removeuicr(self):
         uicr_start_address = 0x10000000


### PR DESCRIPTION
This method does not do what what its name implies, so it should be
stubbed out with a NotImplementedException. However, it is also not used
anywhere else in this repo, and does not override anything in IntelHex,
which makes its need for existence dubious. Is it actually needed? Did maybe
the API of IntelHex change and we need to follow?