### PR TITLE
Remove dependency version constraints

### DIFF
--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -1,0 +1,17 @@
+antlib==1.1b0
+Click==7.0
+crcmod==1.7
+ecdsa==0.13.3
+future==0.17.1
+intelhex==2.2.1
+ipaddress==1.0.22
+libusb1==1.7.1
+pc-ble-driver-py==0.13.0
+piccata==2.0.0
+protobuf==3.10.0
+pyserial==3.4
+pyspinel==1.0.0a3
+PyYAML==5.1.2
+six==1.12.0
+tqdm==4.36.1
+wrapt==1.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,13 @@
-antlib == 1.1b0.post0; sys_platform == 'win32'
-click ~= 7.0
-crcmod ~= 1.7
-ecdsa ~= 0.13.2
-intelhex ~= 2.2
-libusb1 ~= 1.7
-pc_ble_driver_py == 0.12.0
-piccata ~= 2.0
-protobuf ~= 3.8
-pyserial ~= 3.0
-pyspinel == 1.0.0a3
-pywin32 == 225; sys_platform == 'win32'
-pyyaml ~= 5.1
-tqdm ~= 4.36
+antlib >= 1.1b0.post0; sys_platform == 'win32'
+click
+crcmod
+ecdsa
+intelhex
+libusb1
+pc_ble_driver_py >= 0.13
+piccata
+protobuf
+pyserial
+pyspinel >= 1.0.0a3
+pyyaml
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-antlib >= 1.1b0.post0; sys_platform == 'win32'
+antlib >= 1.1b0; sys_platform == 'win32'
 click
 crcmod
 ecdsa
 intelhex
 libusb1
-pc_ble_driver_py >= 0.13
+pc_ble_driver_py >= 0.13.0a0
 piccata
 protobuf
 pyserial

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup(
                      '../libusb/x86/libusb-1.0.dll', '../libusb/x64/libusb-1.0.dll',
                      '../libusb/x64/libusb-1.0.dylib', '../libusb/LICENSE']
     },
+    python_requires='~= 3.6',
     install_requires=reqs,
     zipfile=None,
     tests_require=[


### PR DESCRIPTION
Remove most dependency version constraints from requirements.txt, which
is read by setup.py. This was done so that any project that depends on
this one can choose dependency versions as freely as possible and is
reposible for testing and freezing for its releases. This change also
introduces a requirements-freeze.txt which freezes the dependency
environment to a known good state for nrfutil that will be used for
builds of nrfutil standalone executable.

Sadly this means that installing nrfutil manually trough pip can break
without warning. A possible solution for this is to create a dedicated
package for nrfutil with the frozen dependencies. This would be meant to
be run in an isolated environment using pipx or a simmilar tool.