### PR TITLE
Add sys_platform win32 condtion on antlib in reqs-frozen

### DIFF
--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -1,4 +1,4 @@
-antlib==1.1b0.post0
+antlib==1.1b0.post0 ; sys_platform == 'win32'
 Click==7.0
 crcmod==1.7
 ecdsa==0.13.3


### PR DESCRIPTION
Note that this will need to be added manually after each pip freeze.