### PR TITLE
Fix failing PEM test case

### DIFF
--- a/nordicsemi/dfu/signing.py
+++ b/nordicsemi/dfu/signing.py
@@ -135,8 +135,7 @@ class Signing(object):
         elif output_type == 'code':
             return self.get_vk_code(dbg)
         elif output_type == 'pem':
-            # Return pem as str to conform in type with the other cases.
-            return self.get_vk_pem().decode()
+            return self.get_vk_pem()
         else:
             raise InvalidArgumentException("Invalid argument. Can't get key")
 
@@ -242,7 +241,7 @@ __ALIGN(4) const uint8_t pk[64] =
 
         return vk_code
 
-    def get_vk_pem(self):
+    def get_vk_pem(self) -> str:
         """
         Get the verification key as PEM
         """
@@ -252,4 +251,5 @@ __ALIGN(4) const uint8_t pk[64] =
         vk = self.sk.get_verifying_key()
         vk_pem = vk.to_pem()
 
-        return vk_pem
+        # Return pem as str to conform in type with the other cases.
+        return vk_pem.decode()

--- a/nordicsemi/dfu/tests/test_signing.py
+++ b/nordicsemi/dfu/tests/test_signing.py
@@ -114,10 +114,10 @@ class TestSigning(unittest.TestCase):
 
     def test_get_vk_pem(self):
         key_file_name = 'key.pem'
-        expected_vk_pem = b"-----BEGIN PUBLIC KEY-----\n" \
-                          b"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZY2i7duYH2l9rnIg1oIXq+0/uHAF\n" \
-                          b"7IoFubVru6oX9GCQm67NrXImwgS2ErZi/0/MvRsMkIQQkNg6Wc2tbJgdTA==\n" \
-                          b"-----END PUBLIC KEY-----\n"
+        expected_vk_pem = "-----BEGIN PUBLIC KEY-----\n" \
+                          "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZY2i7duYH2l9rnIg1oIXq+0/uHAF\n" \
+                          "7IoFubVru6oX9GCQm67NrXImwgS2ErZi/0/MvRsMkIQQkNg6Wc2tbJgdTA==\n" \
+                          "-----END PUBLIC KEY-----\n"
 
         signing = Signing()
         signing.load_key(key_file_name)


### PR DESCRIPTION
The change from bytes to strings in `get_vk_pem()` was causing the test
case to fail for two separate but related reasons.

- Perform the decoding of the PEM in the `get_vk_pem()` function rather than the `get_vk` function
- Change test oracle to a string, not byte string