### PR TITLE
Py3 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ This will also retrieve and install all additional required packages.
 
 **Note**: Please refer to the [pc-ble-driver-py PyPI installation note on Windows](https://github.com/NordicSemiconductor/pc-ble-driver-py#installing-from-pypi) if you are running nrfutil on this operating system.
 
-**Note**: When installing on macOS, you may need to add ` --ignore-installed six` when running pip. See [issue #79](https://github.com/NordicSemiconductor/pc-nrfutil/issues/79).
-
 ## Downloading precompiled Windows executable
 
 A Windows standalone executable (.exe) of nrfutil is available for download on the [Releases](https://github.com/NordicSemiconductor/pc-nrfutil/releases) page.

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -194,7 +194,7 @@ KEY_FORMAT = [
 class OptionRequiredIf(click.Option):
 
     def full_process_value(self, ctx, value):
-        value = super(OptionRequiredIf, self).full_process_value(ctx, value)
+        value = super().full_process_value(ctx, value)
         if ('serial_number' not in ctx.params or not ctx.params['serial_number']) and value is None:
             msg = 'Required if "-snr" / "--serial-number" is not defined.'
             raise click.MissingParameter(ctx=ctx, param=self, message=msg)

--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -59,9 +59,6 @@ from pc_ble_driver_py.exceptions import NordicSemiException
 from nordicsemi.lister.device_lister import DeviceLister
 import spinel.util as util
 
-# Python 2 compatibility provided by package future
-from builtins import input
-
 logger = logging.getLogger(__name__)
 
 def ble_driver_init(conn_ic_id):

--- a/nordicsemi/bluetooth/hci/codec.py
+++ b/nordicsemi/bluetooth/hci/codec.py
@@ -38,7 +38,7 @@
 UART_HEADER_OCTET_COUNT = 4
 
 
-class ThreeWireUartPacket(object):
+class ThreeWireUartPacket:
     """
     This class encapsulate a three wire uart packet according to Bluetooth specification
     version 4.0 [Vol 4] part D.

--- a/nordicsemi/dfu/bl_dfu_sett.py
+++ b/nordicsemi/dfu/bl_dfu_sett.py
@@ -53,7 +53,7 @@ from pc_ble_driver_py.exceptions import NordicSemiException
 
 logger = logging.getLogger(__name__)
 
-class BLDFUSettingsStructV1(object):
+class BLDFUSettingsStructV1:
 
     def __init__(self, settings_address):
         self.bytes_count = 92
@@ -72,7 +72,7 @@ class BLDFUSettingsStructV1(object):
         self.last_addr         = settings_address + 0x5C
 
 
-class BLDFUSettingsStructV2(object):
+class BLDFUSettingsStructV2:
 
     def __init__(self, settings_address):
         self.bytes_count = 803 # Entire settings page
@@ -97,7 +97,7 @@ class BLDFUSettingsStructV2(object):
         self.last_addr            = settings_address + 0x322
 
 
-class BLDFUSettings(object):
+class BLDFUSettings:
     """ Class to abstract a bootloader and its settings """
 
     flash_page_51_sz      = 0x400

--- a/nordicsemi/dfu/dfu.py
+++ b/nordicsemi/dfu/dfu.py
@@ -49,7 +49,7 @@ from nordicsemi.dfu.package         import Package
 logger = logging.getLogger(__name__)
 
 
-class Dfu(object):
+class Dfu:
     """ Class to handle upload of a new hex image to the device. """
 
     def __init__(self, zip_file_path, dfu_transport, connect_delay):

--- a/nordicsemi/dfu/dfu_transport_ant.py
+++ b/nordicsemi/dfu/dfu_transport_ant.py
@@ -90,7 +90,7 @@ class ValidationException(NordicSemiException):
 logger = logging.getLogger(__name__)
 
 
-class AntParams(object):
+class AntParams:
     # 2466 MHz
     DEF_RF_FREQ = 66
     # 16 Hz
@@ -110,7 +110,7 @@ class AntParams(object):
         self.network_key = self.DEF_NETWORK_KEY
 
 
-class DfuAdapter(object):
+class DfuAdapter:
     ANT_RSP_TIMEOUT = 100
     ANT_DFU_CHAN = 0
     ANT_NET_KEY_IDX = 0

--- a/nordicsemi/dfu/dfu_transport_ant.py
+++ b/nordicsemi/dfu/dfu_transport_ant.py
@@ -326,7 +326,7 @@ class DfuTransportAnt(DfuTransport):
                  prn=DEFAULT_PRN,
                  debug=DEFAULT_DO_DEBUG):
 
-        super(DfuTransportAnt, self).__init__()
+        super().__init__()
         if ant_config is None:
             ant_config = AntParams()
         self.ant_config     = ant_config
@@ -341,7 +341,7 @@ class DfuTransportAnt(DfuTransport):
 
 
     def open(self):
-        super(DfuTransportAnt, self).open()
+        super().open()
         ant_dev = None
         try:
             ant_dev = antlib.ANTDevice(self.port, 57600,
@@ -368,7 +368,7 @@ class DfuTransportAnt(DfuTransport):
         self.__get_mtu()
 
     def close(self):
-        super(DfuTransportAnt, self).close()
+        super().close()
         self.dfu_adapter.close()
 
     def send_init_packet(self, init_packet):

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -416,8 +416,8 @@ class DfuBLEDriver(BLEDriver):
     @wrapt.synchronized(BLEDriver.api_lock)
     def ble_gap_sec_params_reply(self, conn_handle, sec_status, sec_params, own_keys, peer_keys):
         assert isinstance(sec_status, BLEGapSecStatus), 'Invalid argument type'
-        assert isinstance(sec_params, (BLEGapSecParams, NoneType)), 'Invalid argument type'
-        assert isinstance(peer_keys, NoneType), 'NOT IMPLEMENTED'
+        assert sec_params is None or isinstance(sec_params, BLEGapSecParams), 'Invalid argument type'
+        assert peer_keys is None, 'NOT IMPLEMENTED'
 
         return driver.sd_ble_gap_sec_params_reply(self.rpc_adapter,
                                                   conn_handle,

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -84,7 +84,7 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
     LOCAL_ATT_MTU         = 247
 
     def __init__(self, adapter, bonded=False, keyset=None):
-        super(DFUAdapter, self).__init__()
+        super().__init__()
 
         self.evt_sync           = EvtSync(['connected', 'disconnected', 'sec_params',
                                            'auth_status', 'conn_sec_update'])
@@ -410,7 +410,7 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
 
 class DfuBLEDriver(BLEDriver):
     def __init__(self, serial_port, baud_rate=115200, auto_flash=False):
-        super(DfuBLEDriver, self).__init__(serial_port, baud_rate)
+        super().__init__(serial_port, baud_rate)
 
     @NordicSemiErrorCheck
     @wrapt.synchronized(BLEDriver.api_lock)
@@ -438,7 +438,7 @@ class DfuTransportBle(DfuTransport):
                  target_device_addr=None,
                  baud_rate=1000000,
                  prn=0):
-        super(DfuTransportBle, self).__init__()
+        super().__init__()
         DFUAdapter.LOCAL_ATT_MTU = att_mtu
         self.baud_rate          = baud_rate
         self.serial_port        = serial_port
@@ -455,7 +455,7 @@ class DfuTransportBle(DfuTransport):
         if self.dfu_adapter:
             raise IllegalStateException('DFU Adapter is already open')
 
-        super(DfuTransportBle, self).open()
+        super().open()
         driver           = DfuBLEDriver(serial_port = self.serial_port,
                                         baud_rate   = self.baud_rate)
         adapter          = BLEAdapter(driver)
@@ -474,7 +474,7 @@ class DfuTransportBle(DfuTransport):
 
         if not self.dfu_adapter:
             raise IllegalStateException('DFU Adapter is already closed')
-        super(DfuTransportBle, self).close()
+        super().close()
         self.dfu_adapter.close()
         self.dfu_adapter = None
 

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -61,7 +61,7 @@ class ValidationException(NordicSemiException):
 
 logger = logging.getLogger(__name__)
 
-class Slip(object):
+class Slip:
     SLIP_BYTE_END             = 0o300
     SLIP_BYTE_ESC             = 0o333
     SLIP_BYTE_ESC_END         = 0o334
@@ -112,7 +112,7 @@ class Slip(object):
 
         return (finished, current_state, decoded_data)
 
-class DFUAdapter(object):
+class DFUAdapter:
     def __init__(self, serial_port):
         self.serial_port = serial_port
 

--- a/nordicsemi/dfu/dfu_transport_serial.py
+++ b/nordicsemi/dfu/dfu_transport_serial.py
@@ -175,7 +175,7 @@ class DfuTransportSerial(DfuTransport):
                  prn=DEFAULT_PRN,
                  do_ping=DEFAULT_DO_PING):
 
-        super(DfuTransportSerial, self).__init__()
+        super().__init__()
         self.com_port = com_port
         self.baud_rate = baud_rate
         self.flow_control = 1 if flow_control else 0
@@ -192,7 +192,7 @@ class DfuTransportSerial(DfuTransport):
 
 
     def open(self):
-        super(DfuTransportSerial, self).open()
+        super().open()
         try:
             self.__ensure_bootloader()
             self.serial_port = Serial(port=self.com_port,
@@ -217,7 +217,7 @@ class DfuTransportSerial(DfuTransport):
         self.__get_mtu()
 
     def close(self):
-        super(DfuTransportSerial, self).close()
+        super().close()
         self.serial_port.close()
 
     def send_init_packet(self, init_packet):

--- a/nordicsemi/dfu/dfu_trigger.py
+++ b/nordicsemi/dfu/dfu_trigger.py
@@ -64,7 +64,7 @@ DFU_DETACH_REQUEST = 0
 
 logger = logging.getLogger(__name__)
 
-is_32_bit = ctypes.sizeof(ctypes.c_voidp) == 4
+is_32_bit = ctypes.sizeof(ctypes.c_void_p) == 4
 abs_file_dir = os.path.dirname(os.path.abspath(__file__))
 rel_import_dir = ""
 

--- a/nordicsemi/dfu/init_packet_pb.py
+++ b/nordicsemi/dfu/init_packet_pb.py
@@ -66,7 +66,7 @@ class ValidationTypes(Enum):
     VALIDATE_GENERATED_SHA256 = pb.VALIDATE_SHA256
     VALIDATE_ECDSA_P256_SHA256 = pb.VALIDATE_ECDSA_P256_SHA256
 
-class InitPacketPB(object):
+class InitPacketPB:
     def __init__(self,
                  from_bytes = None,
                  hash_bytes = None,

--- a/nordicsemi/dfu/manifest.py
+++ b/nordicsemi/dfu/manifest.py
@@ -162,7 +162,7 @@ class SoftdeviceBootloaderFirmware(Firmware):
         :param int info_read_only_metadata: The metadata about this firwmare image
         :return: SoftdeviceBootloaderFirmware
         """
-        super(SoftdeviceBootloaderFirmware, self).__init__(
+        super().__init__(
             bin_file,
             dat_file,
             info_read_only_metadata)

--- a/nordicsemi/dfu/manifest.py
+++ b/nordicsemi/dfu/manifest.py
@@ -44,7 +44,7 @@ from pc_ble_driver_py.exceptions import NotImplementedException
 from nordicsemi.dfu.model import HexType, FirmwareKeys
 
 
-class ManifestGenerator(object):
+class ManifestGenerator:
     def __init__(self, firmwares_data):
         """
         The Manifest Generator constructor. Needs a data structure to generate a manifest from.
@@ -99,7 +99,7 @@ class ManifestGenerator(object):
                           separators=(',', ': '))
 
 
-class FWMetaData(object):
+class FWMetaData:
     def __init__(self,
                  is_debug=None,
                  hw_version=None,
@@ -127,7 +127,7 @@ class FWMetaData(object):
         self.bl_size = bl_size
 
 
-class Firmware(object):
+class Firmware:
     def __init__(self,
                  bin_file=None,
                  dat_file=None,

--- a/nordicsemi/dfu/nrfhex.py
+++ b/nordicsemi/dfu/nrfhex.py
@@ -65,7 +65,7 @@ class nRFHex(intelhex.IntelHex):
         :param str bootloader: Optional file path to bootloader firmware
         :return: None
         """
-        super(nRFHex, self).__init__()
+        super().__init__()
         self.arch = arch
         self.file_format = 'hex'
 
@@ -92,7 +92,7 @@ class nRFHex(intelhex.IntelHex):
 
     def _removembr(self):
         mbr_end_address = 0x1000
-        minaddress = super(nRFHex, self).minaddr()
+        minaddress = super().minaddr()
         if minaddress < mbr_end_address:
             for i in range(minaddress, mbr_end_address):
                 self._buf.pop(i, 0)
@@ -128,7 +128,7 @@ class nRFHex(intelhex.IntelHex):
             return nRFHex.s1x0_mbr_end_address
 
     def minaddr(self):
-        min_address = super(nRFHex, self).minaddr()
+        min_address = super().minaddr()
 
         # Lower addresses are reserved for master boot record
         if self.file_format != 'bin':
@@ -180,7 +180,7 @@ class nRFHex(intelhex.IntelHex):
 
         start_address = self.minaddr()
         size = self.size()
-        super(nRFHex, self).tobinfile(fobj, start=start_address, size=size)
+        super().tobinfile(fobj, start=start_address, size=size)
 
         if self.bootloaderhex is not None:
             self.bootloaderhex.tobinfile(fobj)

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -74,7 +74,7 @@ class PacketField(Enum):
     FW_VERSION = 3
     REQUIRED_SOFTDEVICES_ARRAY = 4
 
-class Package(object):
+class Package:
     """
         Packages and unpacks Nordic DFU packages. Nordic DFU packages are zip files that contains firmware and meta-information
         necessary for utilities to perform a DFU on nRF5X devices.

--- a/nordicsemi/dfu/signing.py
+++ b/nordicsemi/dfu/signing.py
@@ -64,7 +64,7 @@ AwEHoUQDQgAEaHYrUu/oFKIXN457GH+8IOuv6OIPBRLqoHjaEKM0wIzJZ0lhfO/A
 53hKGjKEjYT3VNTQ3Zq1YB3o5QSQMP/LRg==
 -----END EC PRIVATE KEY-----"""
 
-class Signing(object):
+class Signing:
     """
     Class for singing of hex-files
     """

--- a/nordicsemi/dfu/util.py
+++ b/nordicsemi/dfu/util.py
@@ -42,15 +42,16 @@ from enum import Enum
 
 # From http://stackoverflow.com/questions/4472901/python-enum-class-with-tostring-fromstring
 class NordicEnum(Enum):
-  @classmethod
-  def tostring(cls, val):
-    for k,v in vars(cls).items():
-        if v==val:
-            return k
+    @classmethod
+    def tostring(cls, val):
+        for k, v in vars(cls).items():
+            if v == val:
+                return k
 
-  @classmethod
-  def fromstring(cls, str):
-      return getattr(cls, str.upper(), None)
+    @classmethod
+    def fromstring(cls, str):
+        return getattr(cls, str.upper(), None)
+
 
 # TODO: Create query function that maps query-result strings with functions
 def query_func(question, default=False):

--- a/nordicsemi/lister/device_lister.py
+++ b/nordicsemi/lister/device_lister.py
@@ -40,7 +40,7 @@ from nordicsemi.lister.windows.lister_win32 import Win32Lister
 from nordicsemi.lister.unix.unix_lister import UnixLister
 
 
-class DeviceLister(object):
+class DeviceLister:
     def __init__(self):
         if sys.platform == 'win32':
             self.lister_backend = Win32Lister()

--- a/nordicsemi/lister/windows/constants.py
+++ b/nordicsemi/lister/windows/constants.py
@@ -46,14 +46,14 @@ class DiGetClassDevsFlags(enum.IntEnum):
 
 
 # noinspection SpellCheckingInspection
-class DevicePropertyKeys(object):
+class DevicePropertyKeys:
     """DEVPKEY_xxx constants"""
     NAME = DevicePropertyKey('{b725f130-47ef-101a-a5f1-02608c9eebac}', 10, 'DEVPKEY_NAME')
     Numa_Proximity_Domain = DevicePropertyKey('{540b947e-8b40-45bc-a8a2-6a0b894cbda2}', 1,
                                               'DEVPKEY_Numa_Proximity_Domain')
 
     # noinspection SpellCheckingInspection
-    class Device(object):
+    class Device:
         """DEVPKEY_Device_xxx constants"""
         ContainerId = DevicePropertyKey('{8c7ed206-3f8a-4827-b3ab-ae9e1faefc6c}', 2,
                                         'DEVPKEY_Device_ContainerId')

--- a/nordicsemi/lister/windows/structures.py
+++ b/nordicsemi/lister/windows/structures.py
@@ -36,7 +36,7 @@ class _GUID(ctypes.Structure):
     ]
 
     def __init__(self, guid="{00000000-0000-0000-0000-000000000000}"):
-        super(ctypes.Structure, self).__init__()
+        super().__init__()
         if isinstance(guid, str):
             ret = _ole32.CLSIDFromString(ctypes.create_unicode_buffer(guid), ctypes.byref(self))
             if ret < 0:
@@ -83,7 +83,7 @@ class DevicePropertyKey(ctypes.Structure):
     ]
 
     def __init__(self, guid, pid, name=None):
-        super(ctypes.Structure, self).__init__()
+        super().__init__()
         self.fmtid.__init__(guid)
         self.pid = pid
         self.name = name
@@ -115,7 +115,7 @@ class DeviceInfoData(ctypes.Structure):
     ]
 
     def __init__(self):
-        super(ctypes.Structure, self).__init__()
+        super().__init__()
         self.cbSize = ctypes.sizeof(self)
 
 class ctypesInternalGUID:

--- a/nordicsemi/lister/windows/structures.py
+++ b/nordicsemi/lister/windows/structures.py
@@ -61,7 +61,7 @@ class _GUID(ctypes.Structure):
 assert ctypes.sizeof(_GUID) == 16
 
 
-class GUID(object):
+class GUID:
     def __init__(self, guid="{00000000-0000-0000-0000-000000000000}"):
         self._guid = _GUID(guid)
 

--- a/nordicsemi/thread/dfu_server.py
+++ b/nordicsemi/thread/dfu_server.py
@@ -119,7 +119,7 @@ class ThreadDfuClient:
 
 Resource = namedtuple('Resource', ['path', 'data'])
 
-class ThreadDfuServer():
+class ThreadDfuServer:
     REALM_LOCAL_ADDR  = ip_address('FF03::1')
 
     SPBLK_SIZE        = 64      # number of CoAP blocks of BLOCK_SZX size each

--- a/nordicsemi/thread/dfu_thread.py
+++ b/nordicsemi/thread/dfu_thread.py
@@ -45,52 +45,52 @@ from nordicsemi.thread.dfu_server import ThreadDfuServer
 logger = logging.getLogger(__name__)
 
 def _get_manifest_items(manifest):
-	import inspect
-	result = []
+    import inspect
+    result = []
 
-	for key, value in inspect.getmembers(manifest):
-		if (key.startswith('__')):
-			continue
-		if not value:
-			continue
-		if inspect.ismethod(value) or inspect.isfunction(value):
-			continue
+    for key, value in inspect.getmembers(manifest):
+        if (key.startswith('__')):
+            continue
+        if not value:
+            continue
+        if inspect.ismethod(value) or inspect.isfunction(value):
+            continue
 
-		result.append((key, value))
+        result.append((key, value))
 
-	return result
+    return result
 
 def _get_file_names(manifest):
-	data_attrs = _get_manifest_items(manifest)
-	if (len(data_attrs) > 1):
-		raise RuntimeError("More than one image present in manifest")
-	data_attrs = data_attrs[0]
-	firmware = data_attrs[1]
-	logger.info("Image type {} found".format(data_attrs[0]))
-	return firmware.dat_file, firmware.bin_file
+    data_attrs = _get_manifest_items(manifest)
+    if (len(data_attrs) > 1):
+        raise RuntimeError("More than one image present in manifest")
+    data_attrs = data_attrs[0]
+    firmware = data_attrs[1]
+    logger.info("Image type {} found".format(data_attrs[0]))
+    return firmware.dat_file, firmware.bin_file
 
 def create_dfu_server(transport, zip_file_path, opts):
-	'''
-	Create a DFU server instance.
-	:param transpoort: A transport to be used.
-	:param zip_file_path: A path to the firmware package.
-	:param opts: Optional parameters:
-		mcast_dfu: An information if multicast DFU is enabled.
-		rate: Multicast block transfer rate, in blocks per second
-		reset_suppress: A delay before sending multicast reset command (in milliseconds). -1 means that no reset will be sent.
-	'''
-	temp_dir = tempfile.mkdtemp(prefix="nrf_dfu_")
-	unpacked_zip_path = os.path.join(temp_dir, 'unpacked_zip')
-	manifest = Package.unpack_package(zip_file_path, unpacked_zip_path)
+    '''
+    Create a DFU server instance.
+    :param transpoort: A transport to be used.
+    :param zip_file_path: A path to the firmware package.
+    :param opts: Optional parameters:
+        mcast_dfu: An information if multicast DFU is enabled.
+        rate: Multicast block transfer rate, in blocks per second
+        reset_suppress: A delay before sending multicast reset command (in milliseconds). -1 means that no reset will be sent.
+    '''
+    temp_dir = tempfile.mkdtemp(prefix="nrf_dfu_")
+    unpacked_zip_path = os.path.join(temp_dir, 'unpacked_zip')
+    manifest = Package.unpack_package(zip_file_path, unpacked_zip_path)
 
-	protocol = piccata.core.Coap(transport)
-	transport.register_receiver(protocol)
+    protocol = piccata.core.Coap(transport)
+    transport.register_receiver(protocol)
 
-	init_file, image_file = _get_file_names(manifest)
+    init_file, image_file = _get_file_names(manifest)
 
-	with open(os.path.join(unpacked_zip_path, init_file), 'rb') as f:
-		init_data = f.read()
-	with open(os.path.join(unpacked_zip_path, image_file), 'rb') as f:
-		image_data = f.read()
+    with open(os.path.join(unpacked_zip_path, init_file), 'rb') as f:
+        init_data = f.read()
+    with open(os.path.join(unpacked_zip_path, image_file), 'rb') as f:
+        image_data = f.read()
 
-	return ThreadDfuServer(protocol, init_data, image_data, opts)
+    return ThreadDfuServer(protocol, init_data, image_data, opts)

--- a/nordicsemi/thread/ncp_flasher.py
+++ b/nordicsemi/thread/ncp_flasher.py
@@ -42,7 +42,7 @@ class NCPFlasher(Flasher):
     ERROR_CODE_VERIFY_ERROR = 55
 
     def __init__(self, serial_port = None, snr = None):
-        Flasher.__init__(self, serial_port, snr)
+        super().__init__(serial_port, snr)
 
     def __get_hex_path(self):
         return os.path.join(os.path.dirname(__file__), 'hex', 'ncp.hex')

--- a/nordicsemi/thread/tncp.py
+++ b/nordicsemi/thread/tncp.py
@@ -51,7 +51,7 @@ import spinel.util as util
 
 logger = logging.getLogger(__name__)
 
-class NCPTransport():
+class NCPTransport:
     '''A CoAP Toolkit compatible transport'''
     CFG_KEY_CHANNEL = 'channel'
     CFG_KEY_PANID = 'panid'

--- a/nordicsemi/thread/tncp.py
+++ b/nordicsemi/thread/tncp.py
@@ -137,7 +137,7 @@ class NCPTransport:
             except Exception as e:
                 logging.exception(e)
         else:
-            logger.warn("Unexpected property received (PROP_ID: {})".format(prop))
+            logger.warning("Unexpected property received (PROP_ID: {})".format(prop))
 
         return consumed
 

--- a/nordicsemi/utility/target_registry.py
+++ b/nordicsemi/utility/target_registry.py
@@ -113,7 +113,7 @@ class FileTargetDatabase(TargetDatabase):
         self.targets = None
 
 
-class TargetRegistry(object):
+class TargetRegistry:
     def __init__(self, target_db=EnvTargetDatabase()):
         self.target_db = target_db
 

--- a/nordicsemi/zigbee/ota_file.py
+++ b/nordicsemi/zigbee/ota_file.py
@@ -66,7 +66,7 @@ OTA_UPGRADE_MAX_HW_VERSION_LENGTH         = 2
     } background_dfu_trigger_t;
 '''
 
-class OTA_file(object):
+class OTA_file:
 
     def __init__(self,
                  file_version,
@@ -124,7 +124,7 @@ class OTA_file(object):
                                   comment]) + '.zigbee'
 
 
-class OTA_header(object):
+class OTA_header:
     def __init__(self,
                  file_id,
                  header_version,

--- a/nordicsemi/zigbee/ota_flasher.py
+++ b/nordicsemi/zigbee/ota_flasher.py
@@ -68,7 +68,7 @@ class OTAFlasher(Flasher):
 
         '''
         # Call the superclass constructor
-        Flasher.__init__(self, serial_port, snr)
+        super().__init__(serial_port, snr)
         # Create a Intel Hex out of the Zigbee Update file
         ih = IntelHex()
         update = open(fw, 'rb').read()

--- a/nordicsemi/zigbee/prod_config.py
+++ b/nordicsemi/zigbee/prod_config.py
@@ -47,7 +47,7 @@ class ProductionConfigTooLargeException(Exception):
     def __init__(self, length):
         self.length = length
 
-class ProductionConfig(object):
+class ProductionConfig:
     PRODUCTION_CONFIG_SIZE_MAX        = 128
     PRODUCTION_CONFIG_MAGIC_NUMBER    = 0xF6DD37E7
     PRODUCTION_CONFIG_VERSION         = 1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -2,7 +2,6 @@ antlib==1.1b0.post0 ; sys_platform == 'win32'
 Click==7.0
 crcmod==1.7
 ecdsa==0.13.3
-future==0.17.1
 intelhex==2.2.1
 ipaddress==1.0.22
 libusb1==1.7.1
@@ -12,6 +11,5 @@ protobuf==3.10.0
 pyserial==3.4
 pyspinel==1.0.0a3
 PyYAML==5.1.2
-six==1.12.0
 tqdm==4.36.1
 wrapt==1.11.2

--- a/tests/bdd/steps/common_steps.py
+++ b/tests/bdd/steps/common_steps.py
@@ -45,7 +45,7 @@ from util import process_pipe, ON_POSIX
 logger = logging.getLogger(__file__)
 
 
-class Exec(object):
+class Exec:
     def __init__(self, exec_path):
         self.path = exec_path
         self.name = os.path.basename(self.path)

--- a/tests/bdd/steps/common_steps.py
+++ b/tests/bdd/steps/common_steps.py
@@ -40,7 +40,7 @@ import logging
 import os
 import subprocess
 from threading import Thread
-from util import process_pipe, ON_POSIX
+from .util import process_pipe, ON_POSIX
 
 logger = logging.getLogger(__file__)
 

--- a/tests/bdd/steps/dfu_steps.py
+++ b/tests/bdd/steps/dfu_steps.py
@@ -38,6 +38,7 @@
 import logging
 import os
 import subprocess
+import time
 
 from click.testing import CliRunner
 from behave import then, given

--- a/tests/bdd/steps/genpkg_generate_dfu_package_steps.py
+++ b/tests/bdd/steps/genpkg_generate_dfu_package_steps.py
@@ -42,7 +42,7 @@ from zipfile import ZipFile
 from behave import given, then, when
 from click.testing import CliRunner
 from nordicsemi.__main__ import cli, int_as_text_to_int
-from common_steps import get_resources_path
+from .common_steps import get_resources_path
 
 
 logger = logging.getLogger(__file__)


### PR DESCRIPTION
Tidy up some low-hanging fruit following the Python 3 port.

Once the exact Python versions are clarified in #275 I can work out which other compatible clean-up can be done. (for example, using f-strings would be a big win for readability in parts).