### PR TITLE
Fix invalid c syntax in key source display

### DIFF
--- a/nordicsemi/dfu/signing.py
+++ b/nordicsemi/dfu/signing.py
@@ -233,7 +233,7 @@ class Signing:
 /** @brief Public key used to verify DFU images */
 __ALIGN(4) const uint8_t pk[64] =
 {{
-    {0}
+    {0},
     {1}
 }};
 """


### PR DESCRIPTION
A comma was missing in the the generated source code for key display (NCP-2834)