### PR TITLE
setup.py: Fix the range of supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
                      '../libusb/x86/libusb-1.0.dll', '../libusb/x64/libusb-1.0.dll',
                      '../libusb/x64/libusb-1.0.dylib', '../libusb/LICENSE']
     },
-    python_requires='>=3.6, <=3.8',
+    python_requires='>=3.6, <3.9',
     install_requires=reqs,
     zipfile=None,
     tests_require=[


### PR DESCRIPTION
The previous '<=3.8' matches 3.8.0 or smaller, instead of the whole 3.8
series as intended. Instead, replace with '<3.9' which will match the
whole of the 3.8 series.