### PR TITLE
Add data_length_update to BLE DFU

### DIFF
--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -5,7 +5,7 @@ ecdsa==0.13.3
 intelhex==2.2.1
 ipaddress==1.0.22
 libusb1==1.7.1
-pc-ble-driver-py==0.14.0
+pc-ble-driver-py==0.14.1
 piccata==2.0.1
 protobuf==3.10.0
 pyserial==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ crcmod
 ecdsa
 intelhex
 libusb1
-pc_ble_driver_py >= 0.14.0
+pc_ble_driver_py >= 0.14.1
 piccata
 protobuf
 pyserial


### PR DESCRIPTION
Data length update needs to be called explicitly in SD v5, it's not automatically adjusted with ATT MTU exchange as was the case for SD v3