### PR TITLE
Fix libusb import error on macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,10 +70,6 @@ jobs:
       vmImage: "macos-10.13"
     steps:
       - bash: |
-          brew rm libusb --force
-          brew install libusb
-        displayName: "Setup toolchain for python $(python_version)"
-      - bash: |
           wget https://www.python.org/ftp/python/$(python_version)/python-$(python_version)-macosx10.9.pkg
           sudo installer -pkg python-$(python_version)-macosx10.9.pkg -target /
         displayName: 'Install python $(python_version)'

--- a/nordicsemi/dfu/dfu_trigger.py
+++ b/nordicsemi/dfu/dfu_trigger.py
@@ -44,8 +44,6 @@ import logging
 
 from pc_ble_driver_py.exceptions import NordicSemiException
 
-if sys.platform != 'win32':
-    import usb1
 
 LIBUSB_ENDPOINT_IN = 0x80
 LIBUSB_ENDPOINT_OUT = 0x00


### PR DESCRIPTION
This PR fixes #295 libusb import error. However it breaks libusb usage in the pyinstaller generated executable on macOS. We need to find a way to fix importing libusb later.