### PR TITLE
Ensure to have word-aligned number of bytes in settings HEX-File

### DIFF
--- a/nordicsemi/dfu/bl_dfu_sett.py
+++ b/nordicsemi/dfu/bl_dfu_sett.py
@@ -273,7 +273,12 @@ class BLDFUSettings:
         # Fill the entire settings page with 0's
         for offset in range(0, self.setts.bytes_count):
             self.ihex[self.bl_sett_addr + offset] = 0x00
-
+            
+        # Make sure the hex-file is 32bit-word-aligned
+        fill_bytes = ((self.setts.bytes_count + 4 - 1) & ~(4 - 1)) - self.setts.bytes_count
+        for offset in range(self.setts.bytes_count, self.setts.bytes_count + fill_bytes):
+            self.ihex[self.bl_sett_addr + offset] = 0xFF
+        
         self._add_value_tohex(self.setts.sett_ver, self.bl_sett_ver)
         self._add_value_tohex(self.setts.app_ver, self.app_ver)
         self._add_value_tohex(self.setts.bl_ver, self.bl_ver)
@@ -310,6 +315,8 @@ class BLDFUSettings:
         if not no_backup:
             for offset in range(0, self.setts.bytes_count):
                 self.ihex[self.backup_address + offset] = self.ihex[self.bl_sett_addr + offset]
+            for offset in range(self.setts.bytes_count, self.setts.bytes_count + fill_bytes):
+                self.ihex[self.backup_address + offset] = 0xFF
 
     def probe_settings(self, base):
         # Unpack CRC and version


### PR DESCRIPTION
Make sure that the number of bytes in the hexfile generated by "nrfutil settings generate" is word-aligned (i.e. divisible by 4).

Excess bytes will be filled with 0xFF.

This allows to use the generated HEX-file directly in e.g. Keil uVision's LOAD command. This would resolve the following devzone case: https://devzone.nordicsemi.com/f/nordic-q-a/57805/dfu-settings-hex-file-generated-by-nrfutil-not-word-aligned