### PR TITLE
Reduced dependency on pc_ble_driver

### DIFF
--- a/nordicsemi/dfu/manifest.py
+++ b/nordicsemi/dfu/manifest.py
@@ -40,7 +40,6 @@ import json
 import os
 
 # Nordic libraries
-from pc_ble_driver_py.exceptions import NotImplementedException
 from nordicsemi.dfu.model import HexType, FirmwareKeys
 
 
@@ -82,7 +81,7 @@ class ManifestGenerator:
             elif key == HexType.SD_BL:
                 self.manifest.softdevice_bootloader = _firmware
             else:
-                raise NotImplementedException("Support for firmware type {0} not implemented yet.".format(key))
+                raise NotImplementedError("Support for firmware type {0} not implemented yet.".format(key))
 
         return self.to_json()
 

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -49,7 +49,6 @@ import hashlib
 
 
 # Nordic libraries
-from pc_ble_driver_py.exceptions import NordicSemiException
 from nordicsemi.dfu.nrfhex import nRFHex
 from nordicsemi.dfu.init_packet_pb import InitPacketPB, DFUType, CommandTypes, ValidationTypes, SigningTypes, HashTypes
 from nordicsemi.dfu.manifest import ManifestGenerator, Manifest
@@ -67,6 +66,8 @@ HexTypeToInitPacketFwTypemap = {
     HexType.EXTERNAL_APPLICATION:   DFUType.EXTERNAL_APPLICATION
 }
 
+class PackageException(Exception):
+    pass
 
 class PacketField(Enum):
     DEBUG_MODE = 1
@@ -569,7 +570,7 @@ DFU Package: <{0}>:
         elif crc == 32:
             return binascii.crc32(data_buffer)
         else:
-            raise NordicSemiException("Invalid CRC type")
+            raise ValueError("Invalid CRC type")
 
     @staticmethod
     def sign_firmware(key, firmware_filename):
@@ -627,19 +628,19 @@ DFU Package: <{0}>:
         """
 
         if not os.path.isfile(package_path):
-            raise NordicSemiException("Package {0} not found.".format(package_path))
+            raise PackageException("Package {0} not found.".format(package_path))
 
         target_dir = os.path.abspath(target_dir)
         target_base_path = os.path.dirname(target_dir)
 
         if not os.path.exists(target_base_path):
-            raise NordicSemiException("Base path to target directory {0} does not exist.".format(target_base_path))
+            raise PackageException("Base path to target directory {0} does not exist.".format(target_base_path))
 
         if not os.path.isdir(target_base_path):
-            raise NordicSemiException("Base path to target directory {0} is not a directory.".format(target_base_path))
+            raise PackageException("Base path to target directory {0} is not a directory.".format(target_base_path))
 
         if os.path.exists(target_dir):
-            raise NordicSemiException(
+            raise PackageException(
                 "Target directory {0} exists, not able to unpack to that directory.",
                 target_dir)
 

--- a/nordicsemi/dfu/signing.py
+++ b/nordicsemi/dfu/signing.py
@@ -55,8 +55,6 @@ try:
 except Exception:
     print("Failed to import ecdsa, cannot do signing")
 
-from pc_ble_driver_py.exceptions import InvalidArgumentException, IllegalStateException
-
 
 keys_default_pem = """-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIGvsrpXh8m/E9bj1dq/0o1aBPQVAFJQ6Pzusx685URE0oAoGCCqGSM49
@@ -96,7 +94,7 @@ class Signing:
         """
         # Add assertion of init_packet
         if self.sk is None:
-            raise IllegalStateException("Can't save key. No key created/loaded")
+            raise AssertionError("Can't save key. No key created/loaded")
 
         # Sign the init-packet
         signature = self.sk.sign(init_packet_data, hashfunc=hashlib.sha256, sigencode=sigencode_string)
@@ -108,7 +106,7 @@ class Signing:
         """
         # Add assertion of init_packet
         if self.sk is None:
-            raise IllegalStateException("Can't save key. No key created/loaded")
+            raise AssertionError("Can't save key. No key created/loaded")
 
         vk = self.sk.get_verifying_key()
 
@@ -125,10 +123,10 @@ class Signing:
         Get public key (as hex, code or pem)
         """
         if self.sk is None:
-            raise IllegalStateException("Can't get key. No key created/loaded")
+            raise AssertionError("Can't get key. No key created/loaded")
 
         if output_type is None:
-            raise InvalidArgumentException("Invalid output type for public key.")
+            raise ValueError("Invalid output type for public key.")
         elif output_type == 'hex':
             return self.get_vk_hex()
         elif output_type == 'code':
@@ -136,33 +134,33 @@ class Signing:
         elif output_type == 'pem':
             return self.get_vk_pem()
         else:
-            raise InvalidArgumentException("Invalid argument. Can't get key")
+            raise ValueError("Invalid argument. Can't get key")
 
     def get_sk(self, output_type, dbg) -> str:
         """
         Get private key (as hex, code or pem)
         """
         if self.sk is None:
-            raise IllegalStateException("Can't get key. No key created/loaded")
+            raise AssertionError("Can't get key. No key created/loaded")
 
         if output_type is None:
-            raise InvalidArgumentException("Invalid output type for private key.")
+            raise ValueError("Invalid output type for private key.")
         elif output_type == 'hex':
             return self.get_sk_hex()
         elif output_type == 'code':
-            raise InvalidArgumentException("Private key cannot be shown as code")
+            raise ValueError("Private key cannot be shown as code")
         elif output_type == 'pem':
             # Return pem as str to conform in type with the other cases.
             return self.sk.to_pem().decode()
         else:
-            raise InvalidArgumentException("Invalid argument. Can't get key")
+            raise ValueError("Invalid argument. Can't get key")
 
     def get_sk_hex(self):
         """
         Get the verification key as hex
         """
         if self.sk is None:
-            raise IllegalStateException("Can't get key. No key created/loaded")
+            raise AssertionError("Can't get key. No key created/loaded")
 
         # Reverse the key for display. This emulates a memory
         # dump of the key interpreted a 256bit little endian
@@ -177,7 +175,7 @@ class Signing:
         Get the verification key as hex
         """
         if self.sk is None:
-            raise IllegalStateException("Can't get key. No key created/loaded")
+            raise AssertionError("Can't get key. No key created/loaded")
 
         # Reverse the two halves of key for display. This
         # emulates a memory dump of the key interpreted as two
@@ -219,7 +217,7 @@ class Signing:
         Get the verification key as code
         """
         if self.sk is None:
-            raise IllegalStateException("Can't get key. No key created/loaded")
+            raise AssertionError("Can't get key. No key created/loaded")
 
         to_two_digit_hex_with_0x = '0x{0:02x}'.format
 
@@ -247,7 +245,7 @@ __ALIGN(4) const uint8_t pk[64] =
         Get the verification key as PEM
         """
         if self.sk is None:
-            raise IllegalStateException("Can't get key. No key created/loaded")
+            raise AssertionError("Can't get key. No key created/loaded")
 
         vk = self.sk.get_verifying_key()
         vk_pem = vk.to_pem()


### PR DESCRIPTION
Removed dependency on `pc_ble_driver` in the following modules:
```
nordicsemi/dfu/manifest.py
nordicsemi/dfu/package.py
nordicsemi/dfu/signing.py
```

Motivation: allows these and some related modules to be used without the
need to install pc_ble_driver. Also prepare for what might be a future
PR with OS native BLE support. Below are my reasoning why the suggested
changes should not break anything :)

NordicSemiException
-------------------
All other exceptions mentioned below inherits from this one (i.e. if
caught but derived Exception changed might break something). Used
(caught) in the following places:

```
nordicsemi/__main__.py
155-    try:
156-        if value.lower() == 'none':
157-            return 'none'
158-        return int_as_text_to_int(value)
159:    except NordicSemiException:
```
OK: local method `int_as_text_to_int()` only raises
`NordicSemiException` (side note, should probably raise
ValueErrorinstead?  looking at the usage it seems it is expected to do
so - possible bug?)

```
nordicsemi/__main__.py
388-    try:
389-        sett.fromhexfile(hex_file)
390:    except NordicSemiException as err:
```
OK: `sett.fromhexfile()` from `nordicsemi/dfu/bl_dfu_sett.py`  only
raises `NordicSemiException`

```
nordicsemi/dfu/dfu_transport_serial.py
325-     try:
326-         trigger.enter_bootloader_mode(device)
327-         logger.info("Serial: DFU bootloader was triggered")
328:     except NordicSemiException as err:
```
OK: `trigger.enter_bootloader_mode()` from
`nordicsemi/dfu/dfu_trigger.py` only raises `NordicSemiException`.

raised in `nordicsemi/dfu/signing.py`, methods `calculate_crc` and
`unpack_package`.  Replaced to ValueError and introduced
PackageException.

NotImplementedException
-----------------------
Only used (raised) in `manifest.py`, never caught. Replaced with
standard builtin `NotImplementedError.

InvalidArgumentException
------------------------
Only used (raised) in `signing.py`, never caught. Replaced with
`ValueError` which could be argued is standard practice (unless there
there is a error that need to explicitly caught).
https://stackoverflow.com/questions/256222

IllegalStateException
---------------------
only used (raised) in `nordicsemi/dfu/dfu_transport_ble.py` (left
untouched). Replaced with `AssertionError` in `signing.py` as it seemed
appropriate.