### PR TITLE
Add zigbee ota.hex to nrfutil.spec

### DIFF
--- a/nrfutil.spec
+++ b/nrfutil.spec
@@ -23,6 +23,8 @@ nrfutil_path = os.path.dirname(os.path.abspath(SPEC))
 datas.append((os.path.join(nrfutil_path, "libusb", "x64", "libusb-1.0.dylib"), os.path.join("libusb", "x64")))
 datas.append((os.path.join(nrfutil_path, "libusb", "x86", "libusb-1.0.dll"), os.path.join("libusb", "x86")))
 datas.append((os.path.join(nrfutil_path, "libusb", "x64", "libusb-1.0.dll"), os.path.join("libusb", "x64")))
+datas.append((os.path.join(nrfutil_path, "nordicsemi", "zigbee", "hex", "ota.hex"),
+              os.path.join("nordicsemi", "zigbee", "hex")))
 
 a = Analysis(['nordicsemi/__main__.py'],
              binaries=None,


### PR DESCRIPTION
Ota.hex was not added into the precompiled file when using pyinstaller.

From #241, the subprocess error was fixed in NordicSemiconductor/pc-ble-driver-py#161, but it then gave a file not found error.