### PR TITLE
Re-add ord(b)

### DIFF
--- a/nordicsemi/dfu/crc16.py
+++ b/nordicsemi/dfu/crc16.py
@@ -46,6 +46,7 @@ def calc_crc16(binary_data: bytes, crc=0xffff):
 
     for b in binary_data:
         crc = (crc >> 8 & 0x00FF) | (crc << 8 & 0xFF00)
+        crc ^= ord(b)
         crc ^= (crc & 0x00FF) >> 4
         crc ^= (crc << 8) << 4
         crc ^= ((crc & 0x00FF) << 4) << 1


### PR DESCRIPTION
Re-add `crc ^= ord(b)` which was removed by a mistake in https://github.com/NordicSemiconductor/pc-nrfutil/commit/809c9bf48179c1cf36077552f128040e1f59eadb#diff-2161db70da96188e7a32f2b4f8ee3f6aL49.