### PR TITLE
license: correctly mark project as having a proprietary license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ class NoseTestCommand(TestCommand):
 setup(
     name="nrfutil",
     version=version.NRFUTIL_VERSION,
-    license="Modified BSD License",
+    license="Other/Proprietary License",
     author="Nordic Semiconductor ASA",
     url="https://github.com/NordicSemiconductor/pc-nrfutil",
     description="Nordic Semiconductor nrfutil utility and Python library",


### PR DESCRIPTION
Project license is not Modified BSD; correct this.

The text "Other/Proprietary License" chosen as per https://pypi.org/classifiers/

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>