### PR TITLE
signing: access private key only once

### DIFF
--- a/nordicsemi/dfu/bl_dfu_sett.py
+++ b/nordicsemi/dfu/bl_dfu_sett.py
@@ -173,7 +173,7 @@ class BLDFUSettings:
         return binascii.crc32(bytearray(list)) & 0xFFFFFFFF
 
     def generate(self, arch, app_file, app_ver, bl_ver, bl_sett_ver, custom_bl_sett_addr, no_backup,
-                 backup_address, app_boot_validation_type, sd_boot_validation_type, sd_file, key_file):
+                 backup_address, app_boot_validation_type, sd_boot_validation_type, sd_file, signer):
 
         self.set_arch(arch)
 
@@ -217,7 +217,7 @@ class BLDFUSettings:
                 self.app_boot_validation_bytes = Package.calculate_sha256_hash(self.app_bin)[::-1]
             elif app_boot_validation_type == 'VALIDATE_ECDSA_P256_SHA256':
                 self.app_boot_validation_type = 3 & 0xffffffff
-                self.app_boot_validation_bytes = Package.sign_firmware(key_file, self.app_bin)
+                self.app_boot_validation_bytes = Package.sign_firmware(signer, self.app_bin)
             else:  # This also covers 'NO_VALIDATION' case
                 self.app_boot_validation_type = 0 & 0xffffffff
                 self.app_boot_validation_bytes = bytes(0)
@@ -257,7 +257,7 @@ class BLDFUSettings:
                 self.sd_boot_validation_bytes = Package.calculate_sha256_hash(self.sd_bin)[::-1]
             elif sd_boot_validation_type == 'VALIDATE_ECDSA_P256_SHA256':
                 self.sd_boot_validation_type = 3 & 0xffffffff
-                self.sd_boot_validation_bytes = Package.sign_firmware(key_file, self.sd_bin)
+                self.sd_boot_validation_bytes = Package.sign_firmware(signer, self.sd_bin)
             else:  # This also covers 'NO_VALIDATION_CASE'
                 self.sd_boot_validation_type = 0 & 0xffffffff
                 self.sd_boot_validation_bytes = bytes(0)

--- a/nordicsemi/dfu/tests/test_bl_dfu_sett.py
+++ b/nordicsemi/dfu/tests/test_bl_dfu_sett.py
@@ -41,6 +41,7 @@ import struct
 import unittest
 from nordicsemi.dfu.bl_dfu_sett import BLDFUSettings
 from nordicsemi.dfu.nrfhex import nRFArch
+from nordicsemi.dfu.signing import Signing
 
 
 class TestBLDFUSettingsV1(unittest.TestCase):
@@ -79,7 +80,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(nRFArch.NRF52, settings.arch)
         self.assertEqual('nRF52', settings.arch_str)
@@ -107,7 +108,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(nRFArch.NRF52, settings.arch)
         self.assertEqual('nRF52', settings.arch_str)
@@ -135,7 +136,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(settings.bl_sett_addr, 0x0006F000)
 
@@ -152,7 +153,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                              app_boot_validation_type=None,
                              sd_boot_validation_type=None,
                              sd_file=None,
-                             key_file=None)
+                             signer=None)
 
         settings = BLDFUSettings()
         settings.generate(arch='NRF52',
@@ -166,7 +167,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(len(list(settings.ihex.todict().keys())), len(list(settings_raw.ihex.todict().keys())) * 2)
 
@@ -183,7 +184,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         backup_dict = {(k + settings.bl_sett_backup_offset): v for k, v in list(settings.ihex.todict().items()) if k < settings.bl_sett_addr}
         settings_dict = {k: v for k, v in list(settings.ihex.todict().items()) if k >= settings.bl_sett_addr}
@@ -202,7 +203,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(settings.backup_address, 0x0006F000)
         self.assertTrue(0x0006F000 in list(settings.ihex.todict().keys()))
@@ -220,7 +221,7 @@ class TestBLDFUSettingsV1(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(settings.backup_address, (0x0006F000 - settings.bl_sett_backup_offset))
         self.assertTrue((0x0006F000 - settings.bl_sett_backup_offset) in list(settings.ihex.todict().keys()))
@@ -267,7 +268,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(nRFArch.NRF52, settings.arch)
         self.assertEqual('nRF52', settings.arch_str)
@@ -301,7 +302,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file='firmwares/s132_nrf52_mini.hex',
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(nRFArch.NRF52, settings.arch)
         self.assertEqual('nRF52', settings.arch_str)
@@ -335,7 +336,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(settings.bl_sett_addr, 0x0006F000)
 
@@ -352,7 +353,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                              app_boot_validation_type=None,
                              sd_boot_validation_type=None,
                              sd_file=None,
-                             key_file=None)
+                             signer=None)
 
         settings = BLDFUSettings()
         settings.generate(arch='NRF52',
@@ -366,7 +367,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(len(list(settings.ihex.todict().keys())), len(list(settings_raw.ihex.todict().keys())) * 2)
 
@@ -383,7 +384,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         backup_dict = {(k + settings.bl_sett_backup_offset): v for k, v in list(settings.ihex.todict().items()) if k < settings.bl_sett_addr}
         settings_dict = {k: v for k, v in list(settings.ihex.todict().items()) if k >= settings.bl_sett_addr}
@@ -402,7 +403,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(settings.backup_address, 0x0006F000)
         self.assertTrue(0x0006F000 in list(settings.ihex.todict().keys()))
@@ -420,7 +421,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(settings.backup_address, (0x0006F000 - settings.bl_sett_backup_offset))
         self.assertTrue((0x0006F000 - settings.bl_sett_backup_offset) in list(settings.ihex.todict().keys()))
@@ -438,7 +439,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type='VALIDATE_GENERATED_CRC',
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(0x1316CFD0, settings.crc)
         self.assertEqual(0x49A0F45A, settings.boot_validation_crc)
@@ -458,7 +459,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type='VALIDATE_GENERATED_SHA256',
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(0x1316CFD0, settings.crc)
         self.assertEqual(0xF78E451E, settings.boot_validation_crc)
@@ -468,6 +469,10 @@ class TestBLDFUSettingsV2(unittest.TestCase):
 
     def test_generate_with_app_boot_validation_ecdsa(self):
         settings = BLDFUSettings()
+
+        signer = Signing()
+        signer.load_key('key.pem')
+
         settings.generate(arch='NRF52',
                           app_file='firmwares/s132_nrf52_mini.hex',
                           app_ver=1,
@@ -479,7 +484,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type='VALIDATE_ECDSA_P256_SHA256',
                           sd_boot_validation_type=None,
                           sd_file=None,
-                          key_file='key.pem')
+                          signer=signer)
 
         # Since ECDSA contains a random component the signature will be different every time
         # it is generated. Therefore only overall structure of the boot validation will be checked.
@@ -499,7 +504,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type='VALIDATE_GENERATED_CRC',
                           sd_file='firmwares/s132_nrf52_mini.hex',
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(0x4637019F, settings.crc)
         self.assertEqual(0xCB5F90FB, settings.boot_validation_crc)
@@ -519,7 +524,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type='VALIDATE_GENERATED_SHA256',
                           sd_file='firmwares/s132_nrf52_mini.hex',
-                          key_file=None)
+                          signer=None)
 
         self.assertEqual(0x4637019F, settings.crc)
         self.assertEqual(0x9C761426, settings.boot_validation_crc)
@@ -529,6 +534,10 @@ class TestBLDFUSettingsV2(unittest.TestCase):
 
     def test_generate_with_sd_boot_validation_ecdsa(self):
         settings = BLDFUSettings()
+
+        signer = Signing()
+        signer.load_key('key.pem')
+
         settings.generate(arch='NRF52',
                           app_file=None,
                           app_ver=1,
@@ -540,7 +549,7 @@ class TestBLDFUSettingsV2(unittest.TestCase):
                           app_boot_validation_type=None,
                           sd_boot_validation_type='VALIDATE_ECDSA_P256_SHA256',
                           sd_file='firmwares/s132_nrf52_mini.hex',
-                          key_file='key.pem')
+                          signer=signer)
 
         # Since ECDSA contains a random component the signature will be different every time
         # it is generated. Therefore only overall structure of the boot validation will be checked.

--- a/nordicsemi/dfu/tests/test_package.py
+++ b/nordicsemi/dfu/tests/test_package.py
@@ -43,6 +43,7 @@ from zipfile import ZipFile
 import shutil
 
 from nordicsemi.dfu.package import Package
+from nordicsemi.dfu.signing import Signing
 
 
 class TestPackage(unittest.TestCase):
@@ -53,10 +54,13 @@ class TestPackage(unittest.TestCase):
         shutil.rmtree(self.work_directory, ignore_errors=True)
 
     def test_generate_package_application(self):
+        signer = Signing()
+        signer.load_key('key.pem')
+
         self.p = Package(app_version=100,
             sd_req=[0x1000, 0xfffe],
             app_fw="firmwares/bar.hex",
-            key_file="key.pem"
+            signer=signer
         )
 
         pkg_name = "mypackage.zip"
@@ -83,11 +87,14 @@ class TestPackage(unittest.TestCase):
                 self.assertTrue('bootloader' not in _json['manifest'])
 
     def test_generate_package_sd_bl(self):
+        signer = Signing()
+        signer.load_key('key.pem')
+
         self.p = Package(app_version=100,
                          sd_req=[0x1000, 0xfffe],
                          softdevice_fw="firmwares/foo.hex",
                          bootloader_fw="firmwares/bar.hex",
-                         key_file="key.pem")
+                         signer=signer)
 
 
         pkg_name = "mypackage.zip"
@@ -112,10 +119,13 @@ class TestPackage(unittest.TestCase):
                 self.assertEqual('sd_bl.dat', _json['manifest']['softdevice_bootloader']['dat_file'])
 
     def test_unpack_package_a(self):
+        signer = Signing()
+        signer.load_key('key.pem')
+
         self.p = Package(app_version=100,
                          sd_req=[0x1000, 0xffff],
                          softdevice_fw="firmwares/bar.hex",
-                         key_file="key.pem")
+                         signer=signer)
         pkg_name = os.path.join(self.work_directory, "mypackage.zip")
         self.p.generate_package(pkg_name, preserve_work_dir=False)
 
@@ -127,10 +137,13 @@ class TestPackage(unittest.TestCase):
 #         self.assertIsNotNone(manifest.softdevice.init_packet_data.firmware_crc16)
 
     def test_unpack_package_b(self):
+        signer = Signing()
+        signer.load_key('key.pem')
+
         self.p = Package(app_version=100,
                          sd_req=[0x1000, 0xffff],
                          softdevice_fw="firmwares/bar.hex",
-                         key_file="key.pem")
+                         signer=signer)
         pkg_name = os.path.join(self.work_directory, "mypackage.zip")
         self.p.generate_package(pkg_name, preserve_work_dir=False)
 
@@ -140,10 +153,13 @@ class TestPackage(unittest.TestCase):
         self.assertEqual('bar.bin', manifest.softdevice.bin_file)
 
     def test_unpack_package_c(self):
+        signer = Signing()
+        signer.load_key('key.pem')
+
         self.p = Package(app_version=100,
                          sd_req=[0x1000, 0xffff],
                          softdevice_fw="firmwares/bar.hex",
-                         key_file="key.pem")
+                         signer=signer)
         pkg_name = os.path.join(self.work_directory, "mypackage.zip")
         self.p.generate_package(pkg_name, preserve_work_dir=False)
 


### PR DESCRIPTION
Pass a Signing() object 'signer' to Package() and Package.sign_firmware(),
instead of a 'key_file' string (path).

Access the private key only once, when generating 'signer', which:

1. Fixes a security issue where caller must write private key to disk
instead of passing it purely in memory eg:

    nrfutil --key-file $(secure-key-retrieval)

2. Gives a small speed improvement.

Fixes NordicSemiconductor/pc-nrfutil#327

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>