### PR TITLE
Use configuration tag=1 when re-connecting to BLE target  

### DIFF
--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -249,7 +249,8 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
                 time.sleep(1)
 
                 self.adapter.connect(address=self.target_device_addr_type,
-                                     conn_params=self.conn_params)
+                                     conn_params=self.conn_params,
+                                     tag=1)
                 self.conn_handle = self.evt_sync.wait('connected')
                 retries -= 1
             else:


### PR DESCRIPTION
Connection configuration tag should also be set to '1' when repeating a connection attempt to a BLE DFU target. Otherwise the Softdevice will reject our 247 byte ATT MTU request. 

This fix should improve DFU reliability in more challenging environments where multiple connection attempts may be needed. 