### PR TITLE
dfu_trigger: fix handling of lower than 0x1000 VIDs and PIDs

### DIFF
--- a/nordicsemi/dfu/dfu_trigger.py
+++ b/nordicsemi/dfu/dfu_trigger.py
@@ -120,10 +120,12 @@ class DFUTrigger:
             self.context.close()
 
     def select_device(self, listed_device):
+        device_vid = int(listed_device.vendor_id, 16)
+        device_pid = int(listed_device.product_id, 16)
         all_devices = self.context.getDeviceList()
         filtered_devices = [dev for dev in all_devices
-            if hex(dev.getVendorID())[2:].lower() == listed_device.vendor_id.lower() and
-            hex(dev.getProductID())[2:].lower() == listed_device.product_id.lower()]
+            if dev.getVendorID() == device_vid and
+            dev.getProductID() == device_pid]
 
         access_error = False
         triggerless_devices = 0


### PR DESCRIPTION
VID and PID are passed as strings to the select_device(), but getVendorID() and getProductID() are returning with integers. Currently the integers are converted to hex strings to compare those with the IDs we are searching for. But with the current int-to-string conversion, the leading 0s are truncated, so such IDs will never match.

As a fix (and slight optimization), converting the input VID and PID to integer instead.
