### PR TITLE
Fix Zigbee DFU command on python3 env

### DIFF
--- a/nordicsemi/zigbee/ota_flasher.py
+++ b/nordicsemi/zigbee/ota_flasher.py
@@ -97,7 +97,7 @@ class OTAFlasher(Flasher):
                 return False
             else:
                 raise
-        return (re.search('^Verified OK.$', result, re.MULTILINE) is not None)
+        return (re.search(b'^Verified OK.$', result, re.MULTILINE) is not None)
 
     def fw_check(self):
         '''Check if all the hex files (OTA Server firmware and Zigbee Update file) were flashed correctly'''


### PR DESCRIPTION
Subprocess check_output command in python3 returns bytes instead of string.