### PR TITLE
Align dfu zigbee command with pc-ble-driver>=0.15.0

### DIFF
--- a/nordicsemi/zigbee/ota_flasher.py
+++ b/nordicsemi/zigbee/ota_flasher.py
@@ -92,11 +92,15 @@ class OTAFlasher(Flasher):
         '''Check if the path_to_file hexfile was flashed correctly'''
         try:
             result = self.verify(path_to_file)
-        except subprocess.CalledProcessError as e:
-            if (e.returncode == OTAFlasher.ERROR_CODE_VERIFY_ERROR):
+        except subprocess.CalledProcessError as e:  # for pc-ble-driver <= 0.14.2, can be removed when requirements
+            # will be updated to >= 0.15.0
+            if e.returncode == OTAFlasher.ERROR_CODE_VERIFY_ERROR:
                 return False
             else:
                 raise
+        except RuntimeError:  # for pc-ble-driver >= 0.15.0
+            return False
+
         return (re.search(b'^Verified OK.$', result, re.MULTILINE) is not None)
 
     def fw_check(self):


### PR DESCRIPTION
The API of call_cmd method changed in pc-ble-driver-py 0.15.0. Previously, the CalledProcessError was raised when nrfjprog command failed. Since version 0.15.0, it is replaced by RuntimeError.
Because RuntimeError has no returncode attribute, there is no good way to check the reason why command failed (parsing command output is not recommended, cause it can be changed).
When requirements of nrfutil are updated, the old code can be removed.