### PR TITLE
Fix/costumer libusb crash

### DIFF
--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.1"
+NRFUTIL_VERSION = "6.1.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click
 crcmod
 ecdsa
 intelhex
-libusb1
+libusb1==1.9.3
 pc_ble_driver_py >= 0.16.1
 piccata
 protobuf


### PR DESCRIPTION
A customer had some issues with the previous version of nrfutil, where downloading the wrong version of libusb1 through pip would cause crashes some of the time https://github.com/NordicSemiconductor/pc-nrfutil/issues/351

- Between certain versions, libusb1 has gone from using pure source file bundles into using wheels with their own dlls. 
- The customer mentioned that their issues were solved when migrating to version "1.7.1". We found similar results when going to version 1.9.3
- version number should also be bumped when releasing this more stable package