### PR TITLE
win32 serial enumeration fix

### DIFF
--- a/nordicsemi/lister/windows/constants.py
+++ b/nordicsemi/lister/windows/constants.py
@@ -57,6 +57,8 @@ class DevicePropertyKeys:
         """DEVPKEY_Device_xxx constants"""
         ContainerId = DevicePropertyKey('{8c7ed206-3f8a-4827-b3ab-ae9e1faefc6c}', 2,
                                         'DEVPKEY_Device_ContainerId')
+        DeviceAddress = DevicePropertyKey('{a45c254e-df1c-4efd-8020-67d146a850e0}', 30,
+                                        'DEVPKEY_Device_Address')
 
 # noinspection SpellCheckingInspection
 DIGCF_DEFAULT = DiGetClassDevsFlags.Default


### PR DESCRIPTION
This fixes serial enumeration on win32 for multiple NRFs connected to an internal hub. If you have e.g. 2 NRFs connected to a hub as non-removable devices windows gives them the same container id. get_serial_serial_no previously only tried matching the container id, thus returning the same serial number for each device on the hub. Now the device address is matched as well.