### PR TITLE
Remove erroneous print

### DIFF
--- a/nordicsemi/dfu/bl_dfu_sett.py
+++ b/nordicsemi/dfu/bl_dfu_sett.py
@@ -373,7 +373,6 @@ class BLDFUSettings:
                 self.probe_settings(BLDFUSettings.bl_sett_52_addr)
                 self.set_arch('NRF52')
             except Exception as e:
-                print(e)
                 try:
                     self.probe_settings(BLDFUSettings.bl_sett_52_qfab_addr)
                     self.set_arch('NRF52QFAB')


### PR DESCRIPTION
When running `nrfutil settings display <file>`, this causes error messages to be printed out when nothing is actually wrong.

For example:

```
Unknown Bootloader DFU settings version: 951509534
```