### PR TITLE
Fix antlib location in bundled pyinstaller executable

### DIFF
--- a/nrfutil.spec
+++ b/nrfutil.spec
@@ -17,7 +17,7 @@ if (sys.platform == "win32"):
     module_ant = importlib.import_module('antlib')
     mod_dir_ant = os.path.dirname(module_ant.__file__)
     shlib_dir_ant = os.path.abspath(mod_dir_ant)
-    datas.append((shlib_dir_ant, '.'))
+    datas.append((shlib_dir_ant, 'antlib'))
 
 nrfutil_path = os.path.dirname(os.path.abspath(SPEC))
 datas.append((os.path.join(nrfutil_path, "libusb", "x64", "libusb-1.0.dylib"), os.path.join("libusb", "x64")))


### PR DESCRIPTION
Using `dfu ant` from the standalone pyinstaller executable (e.g. https://github.com/NordicSemiconductor/pc-nrfutil/releases/download/v6.1.2/nrfutil.exe) yields the following error:

```
$ ./nrfutil.exe dfu ant --package dfu.zip
Traceback (most recent call last):
  File "PyInstaller\loader\pyimod04_ctypes.py", line 53, in __init__
  File "ctypes\__init__.py", line 374, in __init__
FileNotFoundError: Could not find module 'C:\Users\[user]\AppData\Local\Temp\_MEI125402\antlib\win32\ANT_WrappedLib.dll' (or one of its dependencies). Try using the full path with constructor syntax.
```

The antlib DLL is assumed to be located at `antlib/win32/ANT_WrappedLib.dll` within the unpacked bundle, but actual location in the bundle is `win32/ANT_WrappedLib.dll`. This fix should rectify the bundled location.