### PR TITLE
Remove checks to support BL + APP updates

### DIFF
--- a/nordicsemi/__main__.py
+++ b/nordicsemi/__main__.py
@@ -664,17 +664,13 @@ def generate(zipfile,
 
     * BL + SD: Supported.
 
-    * BL + APP: Not supported (use two packages instead).
+    * BL + APP: Supported.
 
     * BL + SD + APP: Supported.
 
     * SD + APP: Supported (SD of same Major Version).
     """
     zipfile_path = zipfile
-
-    # Check combinations
-    if bootloader is not None and application is not None and softdevice is None:
-        raise click.UsageError("Invalid combination: use two .zip packages instead.")
 
     if debug_mode is None:
         debug_mode = False

--- a/nordicsemi/dfu/init_packet_pb.py
+++ b/nordicsemi/dfu/init_packet_pb.py
@@ -132,10 +132,6 @@ class InitPacketPB:
             raise RuntimeError("sd_size is not set. It must be set when type is SOFTDEVICE")
         elif self.init_command.type == pb.BOOTLOADER and self.init_command.bl_size == 0:
             raise RuntimeError("bl_size is not set. It must be set when type is BOOTLOADER")
-        elif self.init_command.type == pb.SOFTDEVICE_BOOTLOADER and \
-                (self.init_command.sd_size == 0 or self.init_command.bl_size == 0):
-            raise RuntimeError("Either sd_size or bl_size is not set. Both must be set when type "
-                               "is SOFTDEVICE_BOOTLOADER")
 
         if self.init_command.fw_version < 0 or self.init_command.fw_version > 0xffffffff or \
            self.init_command.hw_version < 0 or self.init_command.hw_version > 0xffffffff:


### PR DESCRIPTION
As explained in the Nordic Devzone ticket (*1) updates of APP+BL are necessary some times. There is no real reason why nrfutil forbids the creation of such packages. This commit removes these checks and I have successfully created an APP+BL package and updated my device.

(*1) https://devzone.nordicsemi.com/f/nordic-q-a/84879/feature-request-please-allow-app-bl-dfu-upgrades-in-nrfutil

