### PR TITLE
MBTLE-4252: Add signature retransmission and extend transfer timeout

### DIFF
--- a/nordicsemi/dfu/dfu_transport_mesh.py
+++ b/nordicsemi/dfu/dfu_transport_mesh.py
@@ -150,7 +150,7 @@ class DfuTransportMesh(DfuTransport):
     SEND_DATA_PACKET_WAIT_TIME = 0.5 # Time between each data packet
     DFU_PACKET_MAX_SIZE = 16  # The DFU packet max size
     ACK_WAIT_TIME = 0.5 # Time to wait for an ack before attempting to resend a packet.
-    DATA_REQ_WAIT_TIME = 10.0 # Time to wait for missing packet requests after sending all packets
+    DATA_REQ_WAIT_TIME = 20.0 # Time to wait for missing packet requests after sending all packets
     MAX_CONTINUOUS_MESSAGE_INTERBYTE_GAP = 0.1 # Maximal time to wait between two bytes in the same packet
     MAX_RETRIES = 10 # Number of send retries before the serial connection is considered lost.
 
@@ -310,10 +310,12 @@ class DfuTransportMesh(DfuTransport):
             time.sleep(self.interval)
 
         # Wait for any final missing packet requests
-        time.sleep(DfuTransportMesh.DATA_REQ_WAIT_TIME)
-        while len(self.requested_packets) > 0:
-            self.send_packet(SerialPacket(self.requested_packets.popleft()))
-            time.sleep(self.interval)
+        timeout = time.time() + DfuTransportMesh.DATA_REQ_WAIT_TIME
+        while time.time() <= timeout:
+            while len(self.requested_packets) > 0:
+                self.send_packet(SerialPacket(self.requested_packets.popleft()))
+                time.sleep(self.interval)
+                timeout = time.time() + DfuTransportMesh.DATA_REQ_WAIT_TIME
 
         while len(self.pending_packets) > 0:
             time.sleep(0.01)


### PR DESCRIPTION
This PR fixes 2 issues in DFU transfer:
* It adds support for requesting missing signature packets
* It extends timeout of DFU transfer after all segments were sent

Should be used in conjunction with DFU fixes for nRF5 SDK for Mesh.