### PR TITLE
fix(protobuf): pin the package version below 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ intelhex
 libusb1==1.9.3
 pc_ble_driver_py >= 0.16.1
 piccata
-protobuf
+protobuf < 4.0.0
 pyserial
 pyspinel >= 1.0.0a3
 pyyaml


### PR DESCRIPTION
protobuf library was updated previous week to 4.x release and since pc-nrfutil does not pin it down, It breaks the usage