### PR TITLE
Faster remove of uicr/mbr address from loaded hex

### DIFF
--- a/nordicsemi/dfu/nrfhex.py
+++ b/nordicsemi/dfu/nrfhex.py
@@ -85,17 +85,11 @@ class nRFHex(intelhex.IntelHex):
 
     def _removeuicr(self):
         uicr_start_address = 0x10000000
-        maxaddress = self.maxaddr()
-        if maxaddress >= uicr_start_address:
-            for i in range(uicr_start_address, maxaddress + 1):
-                self._buf.pop(i, 0)
-
+        self._buf = {k: v for k, v in self._buf.items() if k < uicr_start_address}
+        
     def _removembr(self):
         mbr_end_address = 0x1000
-        minaddress = super().minaddr()
-        if minaddress < mbr_end_address:
-            for i in range(minaddress, mbr_end_address):
-                self._buf.pop(i, 0)
+        self._buf = {k: v for k, v in self._buf.items() if k > mbr_end_address}
 
     def address_has_magic_number(self, address):
         try:


### PR DESCRIPTION
When hex has high addresses (0x20000000+), dict.pop() over all addresses is very slow, in my use case tens of seconds.
Dict comprehension is much faster, fraction of a second.