### PR TITLE
Revert PR 349

### DIFF
--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -185,6 +185,16 @@ class Package:
                                      boot_validation_type=app_boot_validation_type,
                                      init_packet_data=init_packet_vars)
 
+        # WARNING
+        # The code 0x00 in the sd_req filed translates to deleting the
+        # softdevice, so moving the setting of the sd_req the REQUIRED_SOFTDEVICES_ARRAY field  to
+        # before the `self.add_firmware_info` is called can lead to customers potentially
+        # bricking their devices. There may be configurations that avoid the
+        # issues referenced in
+        # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349PR , but a
+        # stable solution is currently favored, and changes will not be accepted
+        # without some level of testing to ensure that a similar but has not
+        # been introduced. 
         if sd_req is not None:
             init_packet_vars[PacketField.REQUIRED_SOFTDEVICES_ARRAY] = sd_req
 

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -190,8 +190,8 @@ class Package:
         # softdevice. Moving the setting of the `REQUIRED_SOFTDEVICES_ARRAY`
         # field to be `sd_req` to before the `self__.add_firmware_info` call
         # for HexType.EXTERNAL_APPLICATION can lead customers potentially
-        # bricking their devices when updating the app. There may be
-        # configurations that avoid the issues referenced in
+        # bricking their devices when updating the application on the device.
+        # There may be configurations that avoid the issues referenced in
         # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349, but a
         # stable solution is currently favored, and changes will not be
         # accepted without some level of testing to ensure that a similar but

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -187,7 +187,7 @@ class Package:
 
         # WARNING
         # The code 0x00 in the sd_req field translates to deleting the
-        # softdevice, so moving the setting of the sd_req the REQUIRED_SOFTDEVICES_ARRAY field  to
+        # softdevice, so moving the setting of the sd_req the REQUIRED_SOFTDEVICES_ARRAY field to
         # before the `self.add_firmware_info` is called can lead to customers potentially
         # bricking their devices. There may be configurations that avoid the
         # issues referenced in

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -186,19 +186,25 @@ class Package:
                                      init_packet_data=init_packet_vars)
 
         # WARNING
-        # The code 0x00 in the sd_req field translates to deleting the
-        # softdevice. Moving the setting of the `REQUIRED_SOFTDEVICES_ARRAY`
+        # Do not move the setting of the `REQUIRED_SOFTDEVICES_ARRAY`
         # field to be `sd_req` to before the `self__.add_firmware_info` call
-        # for HexType.EXTERNAL_APPLICATION can lead customers potentially
-        # bricking their devices when updating the application on the device.
-        # There may be configurations that avoid the issues referenced in
-        # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349, but a
-        # stable solution is currently favored, and changes will not be
-        # accepted without some level of testing to ensure that a similar but
-        # has not been introduced.
+        # for HexType.EXTERNAL_APPLICATION.
+        #
+        # When doing a dfu update, the sd_req, specifies that whatever is being
+        # updated requires some version of the softdevice. In the case when
+        # somebody does a an update with both an application and a softdevice,
+        # both sd_req and sd_id are used at the same time. Moving assignment up
+        # will cause the versions accepted for the softdevice to also be
+        # accepted for the application, which can lead to invalid updates. If
+        # the value 0x00 is provided, it can also lead to the softdevice being
+        # deleted.
+        #
+        # Moving was tried https://github.com/NordicSemiconductor/pc-nrfutil/pull/349, but a
+        # stable solution is currently favored over one solving this particular
+        # issue. Any changes will have to be sufficiently tested to enusre a
+        # similar bug has not been introduced.
         if sd_req is not None:
             init_packet_vars[PacketField.REQUIRED_SOFTDEVICES_ARRAY] = sd_req
-
 
         if bootloader_fw:
             self.__add_firmware_info(firmware_type=HexType.BOOTLOADER,

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -190,9 +190,9 @@ class Package:
         # softdevice. Moving the setting of the `REQUIRED_SOFTDEVICES_ARRAY`
         # field to be `sd_req` to before the `self__.add_firmware_info` call
         # for HexType.EXTERNAL_APPLICATION can lead customers potentially
-        # bricking their devices when updating the external app. There may be
+        # bricking their devices when updating the app. There may be
         # configurations that avoid the issues referenced in
-        # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349PR, but a
+        # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349, but a
         # stable solution is currently favored, and changes will not be
         # accepted without some level of testing to ensure that a similar but
         # has not been introduced.

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -190,8 +190,8 @@ class Package:
         # softdevice. Moving the setting of the `REQUIRED_SOFTDEVICES_ARRAY`
         # field to be `sd_req` to before the `self__.add_firmware_info` call
         # for HexType.EXTERNAL_APPLICATION can lead customers potentially
-        # bricking their devices.  There may be configurations that avoid the
-        # issues referenced in
+        # bricking their devices when updating the external app. There may be
+        # configurations that avoid the issues referenced in
         # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349PR, but a
         # stable solution is currently favored, and changes will not be
         # accepted without some level of testing to ensure that a similar but

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -187,14 +187,15 @@ class Package:
 
         # WARNING
         # The code 0x00 in the sd_req field translates to deleting the
-        # softdevice, so moving the setting of the sd_req the REQUIRED_SOFTDEVICES_ARRAY field to
-        # before the `self.add_firmware_info` is called can lead to customers potentially
-        # bricking their devices. There may be configurations that avoid the
+        # softdevice. Moving the setting of the `REQUIRED_SOFTDEVICES_ARRAY`
+        # field to be `sd_req` to before the `self__.add_firmware_info` call
+        # for HexType.EXTERNAL_APPLICATION can lead customers potentially
+        # bricking their devices.  There may be configurations that avoid the
         # issues referenced in
         # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349PR, but a
-        # stable solution is currently favored, and changes will not be accepted
-        # without some level of testing to ensure that a similar but has not
-        # been introduced. 
+        # stable solution is currently favored, and changes will not be
+        # accepted without some level of testing to ensure that a similar but
+        # has not been introduced.
         if sd_req is not None:
             init_packet_vars[PacketField.REQUIRED_SOFTDEVICES_ARRAY] = sd_req
 

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -176,8 +176,6 @@ class Package:
 
         self.firmwares_data = {}
 
-        if sd_req is not None:
-            init_packet_vars[PacketField.REQUIRED_SOFTDEVICES_ARRAY] = sd_req
 
         if app_fw:
             firmware_type = HexType.EXTERNAL_APPLICATION if is_external else HexType.APPLICATION
@@ -186,6 +184,9 @@ class Package:
                                      filename=app_fw,
                                      boot_validation_type=app_boot_validation_type,
                                      init_packet_data=init_packet_vars)
+
+        if sd_req is not None:
+            init_packet_vars[PacketField.REQUIRED_SOFTDEVICES_ARRAY] = sd_req
 
 
         if bootloader_fw:

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -186,7 +186,7 @@ class Package:
                                      init_packet_data=init_packet_vars)
 
         # WARNING
-        # The code 0x00 in the sd_req filed translates to deleting the
+        # The code 0x00 in the sd_req field translates to deleting the
         # softdevice, so moving the setting of the sd_req the REQUIRED_SOFTDEVICES_ARRAY field  to
         # before the `self.add_firmware_info` is called can lead to customers potentially
         # bricking their devices. There may be configurations that avoid the

--- a/nordicsemi/dfu/package.py
+++ b/nordicsemi/dfu/package.py
@@ -191,7 +191,7 @@ class Package:
         # before the `self.add_firmware_info` is called can lead to customers potentially
         # bricking their devices. There may be configurations that avoid the
         # issues referenced in
-        # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349PR , but a
+        # https://github.com/NordicSemiconductor/pc-nrfutil/pull/349PR, but a
         # stable solution is currently favored, and changes will not be accepted
         # without some level of testing to ensure that a similar but has not
         # been introduced. 

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.6"
+NRFUTIL_VERSION = "6.1.7"


### PR DESCRIPTION
Accepting PR 349 caused a critical issue, resulting in a critical issue when --sd-req is 0x00. 

This PR is a hotfix that simply reverts the changes of that PR. 