### PR TITLE
Fix Signing.verify to use correct endianness

### DIFF
--- a/nordicsemi/dfu/signing.py
+++ b/nordicsemi/dfu/signing.py
@@ -112,7 +112,9 @@ class Signing:
 
         # Verify init packet
         try:
-            vk.verify(signature, init_packet, hashfunc=hashlib.sha256)
+            # swap signature back, as done in sign function
+            swapped_signature = signature[31::-1] + signature[63:31:-1]
+            vk.verify(swapped_signature, init_packet, hashfunc=hashlib.sha256)
         except:
             return False
 


### PR DESCRIPTION
Signing.sign swaps the endianness of the signature. Verify must swap it, too, so that verifying succeeds.

(Verifying is currently not used, i.e. theres no package verify, but this would save some guessing why it won't verify correctly).